### PR TITLE
feat: multi-version support from 1.8 to 26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,80 @@
 
 Um sistema completo de mercado para servidores de Minecraft, organizado por menus, informações salvas em banco de dados SQL e com uma robusta [API](https://github.com/NextPlugins/NextMarket/blob/master/src/main/java/com/nextplugins/nextmarket/api/NextMarketAPI.java) para desenvolvedores. [Prints in-game](https://imgur.com/gallery/pfn8wBE).
 
+## Compatibilidade
+
+| | |
+|--|--|
+| **Minecraft** | **1.8.8 → 26.2** (Spigot / Paper e forks) |
+| **Java do servidor** | Java 8 (1.8–1.16), Java 16+ (1.17), Java 17+ (1.18–1.20.4), Java 21+ (1.20.5+ / 26.x) |
+| **Bytecode do plugin** | Java 8 (um único JAR para todas as versões) |
+
+A compatibilidade multi-versão usa:
+
+- [XSeries](https://github.com/CryptoMorin/XSeries) — materiais, enchantments e heads
+- [NBT-API](https://github.com/tr7zw/Item-NBT-API) — tags NBT de categorias
+- GUI própria em Bukkit (`Inventory` / `InventoryHolder`) — sem dependência de inventory-api abandonada
+- Camada `compat` — detecção de versão, main hand, itens e skulls
+
+> **Nota:** itens serializados no SQL são válidos **na mesma versão major do servidor**. Subir o servidor de 1.8 para 1.20 (ou 26.x) pode invalidar stacks antigos no banco — limitação do Bukkit, não do plugin.
+
 ## Comandos
-|Comando         |Descrição                      |Permissão                    |
-|----------------|-------------------------------|-----------------------------|
-|/mercado        |Exibe todos os comandos do plugin|`nextmarket.use`           |
-|/mercado ver    |Exibe o menu de categorias do mercado|`nextmarket.use`       |
-|/mercado vender |Coloque um item à venda	     |`nextmarket.use`			   |
-|/mercado pessoal|Veja os itens que anunciaram especialmente para você|`nextmarket.use`			   |
-|/mercado anunciados|Veja os itens que você anunciou no mercado	     |`nextmarket.use`			   |
+
+| Comando | Descrição | Permissão |
+|---------|-----------|-----------|
+| `/mercado` | Exibe todos os comandos do plugin | `nextmarket.use` |
+| `/mercado ver` | Exibe o menu de categorias do mercado | `nextmarket.use` |
+| `/mercado vender <valor> [jogador]` | Coloque um item à venda | `nextmarket.use` |
+| `/mercado pessoal` | Veja os itens anunciados especialmente para você | `nextmarket.use` |
+| `/mercado anunciados` | Veja os itens que você anunciou no mercado | `nextmarket.use` |
+| `/mercado info` | Informações do plugin (admin) | `nextmarket.admin` |
 
 ## Download
 
-Você pode encontrar o plugin pronto para baixar [**aqui**](https://github.com/NextPlugins/NextMarket/releases), ou se você quiser, pode optar por clonar o repositório e dar build no plugin com suas alterações.
+Você pode encontrar o plugin pronto para baixar [**aqui**](https://github.com/NextPlugins/NextMarket/releases), ou clonar o repositório e buildar:
+
+```bash
+./gradlew shadowJar
+# artefato: build/libs/NextMarket-2.0.0.jar
+```
 
 ## Configuração
 
-O plugin conta com dois arquivos de configuração `config.yml` e `categories.yml` em que você pode alterar mensagens, menus, categorias do mercado e outras configurações.
+O plugin conta com dois arquivos de configuração, `config.yml` e `categories.yml`.
+
+### Materiais (`categories.yml`)
+
+Nomes **modernos** e **legacy** são aceitos. O que não existir na versão do servidor é ignorado (com warning no console).
+
+```yaml
+icon:
+  material: DIAMOND_SWORD   # ou nome legacy
+  data: 0                   # só relevante em 1.8–1.12
+  enchant: true
+  inventorySlot: 10
+
+configuration:
+  materials:
+    - DIAMOND_SWORD
+    - WOOL:14               # data legacy
+    - RED_WOOL              # equivalente moderno
+    - WOOL:all              # ignora data
+    - PLAYER_HEAD
+    - SKULL_ITEM            # sinônimo legacy (1.8–1.12)
+  names: []
+  nbts: []
+```
 
 ## Dependências
-O NextMarket apenas precisa do [Vault](https://www.spigotmc.org/resources/vault.34315/) e de algum plugin de economia. As dependências de desenvolvimento serão baixadas automáticamente quando o plugin for habilitado pela primeira vez.
 
-### Tecnologias usadas
--   [Google Guice](https://github.com/google/guice) - Fornece suporte para injeção de dependência usando anotações.
+- [Vault](https://www.spigotmc.org/resources/vault.34315/) + plugin de economia
 
-**APIs e Frameworks**
+Dependências de desenvolvimento (XSeries, NBT-API, Guice, sql-provider, command-framework) vêm **shaded** no JAR.
 
--   [command-framework](https://github.com/SaiintBrisson/command-framework) - Framework para criação e gerenciamento de comandos.
--   [inventory-api](https://github.com/HenryFabio/inventory-api) - API para criação e o gerenciamento de inventários customizados.
--   [sql-provider](https://github.com/henryfabio/sql-provider) - Provê a conexão com o banco de dados.
+### Tecnologias
+
+- [Google Guice](https://github.com/google/guice) — injeção de dependência
+- [command-framework](https://github.com/SaiintBrisson/command-framework) — comandos
+- [sql-provider](https://github.com/henryfabio/sql-provider) — SQLite / MySQL
+- [XSeries](https://github.com/CryptoMorin/XSeries) — multi-versão
+- [NBT-API](https://github.com/tr7zw/Item-NBT-API) — NBT multi-versão

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 plugins {
     id "java"
-
-    id 'com.github.johnrengelman.shadow' version '5.0.0'
-    id 'net.minecrell.plugin-yml.bukkit' version '0.3.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'net.minecrell.plugin-yml.bukkit' version '0.5.3'
 }
 
 group 'com.nextplugins'
-version "1.3.3"
+version "2.0.0"
 
 tasks.build.dependsOn('shadowJar')
 
@@ -16,26 +15,27 @@ repositories {
 
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
     maven { url = 'https://oss.sonatype.org/content/groups/public/' }
-
-    maven { url = 'https://repo.codemc.org/repository/maven-public' }
-
+    maven { url = 'https://repo.codemc.io/repository/maven-public/' }
+    maven { url = 'https://repo.codemc.org/repository/maven-public/' }
     maven { url = 'https://jitpack.io/' }
 }
 
 dependencies {
-    compileOnly "org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT"
+    // Mid-range API: available methods from classic Bukkit without pulling 26.x-only APIs.
+    // Multi-version behavior is handled by XSeries + the compat layer at runtime.
+    compileOnly "org.spigotmc:spigot-api:1.12.2-R0.1-SNAPSHOT"
     compileOnly "com.github.MilkBowl:VaultAPI:1.7"
 
+    implementation 'com.github.cryptomorin:XSeries:13.7.1'
+    implementation 'de.tr7zw:item-nbt-api:2.15.7'
+
     implementation 'com.github.Yuhtin:update-checker:1.2'
-    implementation 'com.github.HenryFabio:inventory-api:2.0.3'
     implementation 'com.github.HenryFabio:sql-provider:9561f20fd2'
-    implementation 'de.tr7zw:item-nbt-api:2.11.3'
 
     implementation 'com.github.SaiintBrisson.command-framework:bukkit:1.2.0'
     implementation "com.google.inject:guice:5.0.1"
 
-    def lombok = "org.projectlombok:lombok:1.18.16"
-
+    def lombok = "org.projectlombok:lombok:1.18.30"
     compileOnly lombok
     annotationProcessor lombok
 }
@@ -45,15 +45,19 @@ bukkit {
     authors = ['NextPlugins']
     website = 'https://nextplugins.com.br'
     version = "${project.version}"
+    // Present on 1.13+; ignored on 1.8–1.12. Enables modern material names with XSeries.
     apiVersion = "1.13"
     depend = ['Vault']
 }
 
 shadowJar {
-    archiveName("${project.name}-${project.version}.jar")
+    archiveFileName = "${project.name}-${project.version}.jar"
+
+    relocate 'com.cryptomorin.xseries', 'com.nextplugins.nextmarket.libs.xseries'
+    relocate 'de.tr7zw.changeme.nbtapi', 'com.nextplugins.nextmarket.libs.nbtapi'
+    relocate 'de.tr7zw.annotations', 'com.nextplugins.nextmarket.libs.nbtapi.annotations'
 
     relocate 'com.yuhtin.updatechecker', 'com.nextplugins.nextmarket.libs.updatechecker'
-    relocate 'com.henryfabio.minecraft.inventoryapi', 'com.nextplugins.nextmarket.libs.inventoryapi'
 
     relocate 'com.henryfabio.sqlprovider', 'com.nextplugins.nextmarket.libs.sqlprovider'
     relocate 'com.zaxxer.hikari', 'com.nextplugins.nextmarket.libs.hikari'
@@ -64,14 +68,13 @@ shadowJar {
     relocate 'com.google.common', 'com.nextplugins.nextmarket.libs.guice.common'
     relocate 'com.google.inject', 'com.nextplugins.nextmarket.libs.guice.inject'
     relocate 'com.google.thirdparty', 'com.nextplugins.nextmarket.libs.guice.thirdparty'
-
-    relocate 'de.tr7zw.changeme.nbtapi', 'com.nextplugins.nextmarket.libs.nbtapi'
-    relocate 'de.tr7zw.annotations', 'com.nextplugins.nextmarket.libs.annotations'
 }
 
-compileJava {
-    options.encoding = "UTF-8"
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = "UTF-8"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/nextplugins/nextmarket/NextMarket.java
+++ b/src/main/java/com/nextplugins/nextmarket/NextMarket.java
@@ -3,16 +3,17 @@ package com.nextplugins.nextmarket;
 import com.google.common.base.Stopwatch;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.henryfabio.minecraft.inventoryapi.manager.InventoryManager;
 import com.henryfabio.sqlprovider.connector.SQLConnector;
 import com.henryfabio.sqlprovider.executor.SQLExecutor;
 import com.nextplugins.nextmarket.api.NextMarketAPI;
 import com.nextplugins.nextmarket.api.metric.MetricProvider;
 import com.nextplugins.nextmarket.command.MarketCommand;
+import com.nextplugins.nextmarket.compat.ServerVersion;
 import com.nextplugins.nextmarket.configuration.ConfigurationLoader;
 import com.nextplugins.nextmarket.dao.SQLProvider;
 import com.nextplugins.nextmarket.guice.PluginModule;
 import com.nextplugins.nextmarket.hook.EconomyHook;
+import com.nextplugins.nextmarket.inventory.menu.MenuListener;
 import com.nextplugins.nextmarket.listener.ProductBuyListener;
 import com.nextplugins.nextmarket.listener.ProductCreateListener;
 import com.nextplugins.nextmarket.listener.ProductRemoveListener;
@@ -63,6 +64,8 @@ public final class NextMarket extends JavaPlugin {
     @Override
     public void onEnable() {
         getLogger().info("Iniciando carregamento do plugin.");
+        getLogger().info("Servidor detectado: Minecraft " + ServerVersion.asString()
+                + (ServerVersion.isLegacy() ? " (legacy materials)" : " (flattening)"));
 
         val loadTime = Stopwatch.createStarted();
         if (updateChecker.canUpdate()) {
@@ -79,7 +82,10 @@ public final class NextMarket extends JavaPlugin {
         }
 
         this.categoriesConfig = ConfigurationLoader.of("categories.yml").saveResource().create();
-        InventoryManager.enable(this);
+
+        if (!de.tr7zw.changeme.nbtapi.NBT.preloadApi()) {
+            getLogger().warning("NBT-API não inicializou corretamente; matching por NBT de categorias pode falhar.");
+        }
 
         sqlConnector = SQLProvider.of(this).setup();
         sqlExecutor = new SQLExecutor(sqlConnector);
@@ -97,6 +103,7 @@ public final class NextMarket extends JavaPlugin {
 
         enableCommandFrame();
 
+        registerListener(MenuListener.class);
         registerListener(ProductCreateListener.class);
         registerListener(ProductRemoveListener.class);
         registerListener(ProductBuyListener.class);

--- a/src/main/java/com/nextplugins/nextmarket/api/model/product/MaterialData.java
+++ b/src/main/java/com/nextplugins/nextmarket/api/model/product/MaterialData.java
@@ -1,34 +1,92 @@
 package com.nextplugins.nextmarket.api.model.product;
 
+import com.cryptomorin.xseries.XMaterial;
+import com.nextplugins.nextmarket.compat.Items;
+import com.nextplugins.nextmarket.compat.ServerVersion;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NonNull;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * @author Yuhtin
- * Github: https://github.com/Yuhtin
+ * Cross-version material reference. Prefer {@link XMaterial} over raw Bukkit {@link Material}
+ * so the same config works from 1.8 through modern releases.
  */
-
-@Data
+@Getter
 @AllArgsConstructor
 public class MaterialData {
 
-    private final Material material;
-    private final int data;
+    private final XMaterial xMaterial;
+    /** Legacy durability/data; only meaningful on pre-1.13 when {@link #ignoreData} is false. */
+    private final Integer data;
     private final boolean ignoreData;
 
     public static MaterialData of(@NonNull ItemStack item, boolean ignoreData) {
-        return new MaterialData(item.getType(), item.getDurability(), ignoreData);
+        XMaterial matched = XMaterial.matchXMaterial(item);
+        Integer data = null;
+        if (!ignoreData && ServerVersion.isLegacy()) {
+            data = (int) item.getDurability();
+        }
+        return new MaterialData(matched, data, ignoreData);
+    }
+
+    /**
+     * Legacy constructor kept for call sites that still pass Bukkit Material.
+     * Prefer constructors that take {@link XMaterial}.
+     */
+    public MaterialData(Material material, int data, boolean ignoreData) {
+        XMaterial matched = material == null ? XMaterial.STONE : XMaterial.matchXMaterial(material);
+        this.xMaterial = matched;
+        this.data = ignoreData ? null : data;
+        this.ignoreData = ignoreData;
+    }
+
+    public Material getMaterial() {
+        Material parsed = xMaterial != null ? xMaterial.parseMaterial() : null;
+        return parsed != null ? parsed : Material.STONE;
+    }
+
+    public int getData() {
+        if (data != null) return data;
+        if (xMaterial != null) return xMaterial.getData();
+        return 0;
     }
 
     public ItemStack toItemStack(int quantity) {
-        return new ItemStack(material, quantity, (short) data);
+        if (xMaterial == null || !xMaterial.isSupported()) {
+            return Items.fallbackBarrier();
+        }
+
+        ItemStack stack = xMaterial.parseItem();
+        if (stack == null) {
+            return Items.fallbackBarrier();
+        }
+
+        stack.setAmount(Math.max(1, quantity));
+
+        if (!ignoreData && data != null && ServerVersion.isLegacy()) {
+            stack.setDurability(data.shortValue());
+        }
+
+        return stack;
+    }
+
+    public boolean matches(ItemStack itemStack) {
+        if (itemStack == null || xMaterial == null) return false;
+        XMaterial other = XMaterial.matchXMaterial(itemStack);
+        if (other != xMaterial) return false;
+        if (ignoreData || !ServerVersion.isLegacy() || data == null) return true;
+        return itemStack.getDurability() == data.shortValue();
     }
 
     public boolean equals(MaterialData materialData) {
-        return materialData.getMaterial() == material && (ignoreData || materialData.getData() == data);
+        if (materialData == null || xMaterial == null || materialData.xMaterial == null) return false;
+        if (xMaterial != materialData.xMaterial) return false;
+        if (ignoreData || materialData.ignoreData || !ServerVersion.isLegacy()) return true;
+        int thisData = data != null ? data : 0;
+        int otherData = materialData.data != null ? materialData.data : 0;
+        return thisData == otherData;
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/command/MarketCommand.java
+++ b/src/main/java/com/nextplugins/nextmarket/command/MarketCommand.java
@@ -1,7 +1,6 @@
 package com.nextplugins.nextmarket.command;
 
 import com.google.inject.Inject;
-import com.henryfabio.minecraft.inventoryapi.viewer.property.ViewerPropertyMap;
 import com.nextplugins.nextmarket.NextMarket;
 import com.nextplugins.nextmarket.api.event.ProductCreateEvent;
 import com.nextplugins.nextmarket.api.model.category.Category;
@@ -67,6 +66,7 @@ public final class MarketCommand {
         context.sendMessage(MessageUtils.colored("  &fCategorias: &e" + categoryManager.getCategoryMap().size()));
         context.sendMessage(MessageUtils.colored("  &fItens registrados: &e" + itemCount));
         context.sendMessage(MessageUtils.colored("  &fVersão atual: &e" + updateChecker.getCurrentVersion()));
+        context.sendMessage(MessageUtils.colored("  &fServidor: &e" + com.nextplugins.nextmarket.compat.ServerVersion.asString()));
 
         if (!MessageUtils.sendUpdateMessage(context.getSender())) {
             context.sendMessage("");
@@ -79,21 +79,23 @@ public final class MarketCommand {
             async = true
     )
     public void showMarketCommand(Context<Player> context, @Optional String id) {
+        Player player = context.getSender();
         if (id == null) {
-            inventoryRegistry.getMarketInventory().openInventory(context.getSender());
-        } else {
-            Category category = categoryManager.findCategoryById(id).orElse(null);
-            if (category == null) {
-                String message = MessageValue.get(MessageValue::categoryNotExists);
-                context.sendMessage(message);
-            } else {
-                inventoryRegistry.getCategoryInventory().openInventory(context.getSender(), viewer -> {
-                    ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-                    propertyMap.set("category", category);
-                    propertyMap.set("products", productStorage.findProductsByCategory(category));
-                });
-            }
+            runSync(() -> inventoryRegistry.getMarketInventory().openInventory(player));
+            return;
         }
+
+        Category category = categoryManager.findCategoryById(id).orElse(null);
+        if (category == null) {
+            context.sendMessage(MessageValue.get(MessageValue::categoryNotExists));
+            return;
+        }
+
+        runSync(() -> inventoryRegistry.getCategoryInventory().openInventory(
+                player,
+                category,
+                productStorage.findProductsByCategory(category)
+        ));
     }
 
     @Command(
@@ -102,13 +104,15 @@ public final class MarketCommand {
             async = true
     )
     public void personalMarketCommand(Context<Player> context) {
-        try {
-            PersonalMarketInventory personalMarketInventory = inventoryRegistry.getPersonalMarketInventory();
-            personalMarketInventory.openInventory(context.getSender());
-        } catch (Throwable ignored) {
-            context.getSender().closeInventory();
-            context.getSender().sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
-        }
+        Player player = context.getSender();
+        runSync(() -> {
+            try {
+                inventoryRegistry.getPersonalMarketInventory().openInventory(player);
+            } catch (Throwable ignored) {
+                player.closeInventory();
+                player.sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
+            }
+        });
     }
 
     @Command(
@@ -119,27 +123,29 @@ public final class MarketCommand {
     )
     public void sellMarketCommand(Context<Player> context, String priceText, @Optional String destination) {
         if (priceText == null) {
-
             context.sendMessage(MessageValue.get(MessageValue::correctUsageSellMessage));
             return;
-
         }
 
         double price = NumberUtils.parse(priceText);
         if (NumberUtils.isInvalid(price)) {
-
             context.getSender().sendMessage(MessageValue.get(MessageValue::invalidNumber));
             return;
-
         }
 
-        Product product = productManager.createProduct(context.getSender(), destination, price);
+        Player player = context.getSender();
+        Product product = productManager.createProduct(player, destination, price);
         if (product == null) return;
 
-        inventoryRegistry.getConfirmationInventory().openConfirmation(context.getSender(), "Venda de item", () -> {
-            ProductCreateEvent createEvent = new ProductCreateEvent(context.getSender(), product);
-            Bukkit.getPluginManager().callEvent(createEvent);
-        }, product.getItemStack());
+        runSync(() -> inventoryRegistry.getConfirmationInventory().openConfirmation(
+                player,
+                "Venda de item",
+                () -> {
+                    ProductCreateEvent createEvent = new ProductCreateEvent(player, product);
+                    Bukkit.getPluginManager().callEvent(createEvent);
+                },
+                product.getItemStack()
+        ));
     }
 
     @Command(
@@ -148,13 +154,24 @@ public final class MarketCommand {
             async = true
     )
     public void sellingMarketCommand(Context<Player> context) {
-        try {
-            SellingMarketInventory sellingMarketInventory = inventoryRegistry.getSellingMarketInventory();
-            sellingMarketInventory.openInventory(context.getSender());
-        } catch (Throwable ignored) {
-            context.getSender().closeInventory();
-            context.getSender().sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
+        Player player = context.getSender();
+        runSync(() -> {
+            try {
+                inventoryRegistry.getSellingMarketInventory().openInventory(player);
+            } catch (Throwable ignored) {
+                player.closeInventory();
+                player.sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
+            }
+        });
+    }
+
+    private void runSync(Runnable runnable) {
+        if (Bukkit.isPrimaryThread()) {
+            runnable.run();
+            return;
         }
+        Bukkit.getScheduler().runTask(NextMarket.getInstance(), runnable);
     }
 
 }
+

--- a/src/main/java/com/nextplugins/nextmarket/compat/Items.java
+++ b/src/main/java/com/nextplugins/nextmarket/compat/Items.java
@@ -1,0 +1,191 @@
+package com.nextplugins.nextmarket.compat;
+
+import com.cryptomorin.xseries.XEnchantment;
+import com.cryptomorin.xseries.XMaterial;
+import com.nextplugins.nextmarket.NextMarket;
+import com.nextplugins.nextmarket.api.model.product.MaterialData;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * Cross-version item creation and decoration using XSeries.
+ */
+public final class Items {
+
+    private Items() {
+    }
+
+    public static Optional<XMaterial> matchMaterial(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return Optional.empty();
+        }
+        return XMaterial.matchXMaterial(name.trim());
+    }
+
+    /**
+     * Parses {@code MATERIAL} or {@code MATERIAL:data} (and {@code MATERIAL:all} for ignore-data).
+     */
+    public static MaterialData parseMaterialData(String raw) {
+        if (raw == null || raw.trim().isEmpty()) {
+            return null;
+        }
+
+        String materialName = raw.trim();
+        Integer data = null;
+        boolean ignoreData = true;
+
+        if (materialName.contains(":")) {
+            String[] args = materialName.split(":", 2);
+            materialName = args[0].trim();
+            String type = args[1].trim();
+            if (!type.equalsIgnoreCase("all")) {
+                try {
+                    data = Integer.parseInt(type);
+                    ignoreData = false;
+                } catch (NumberFormatException e) {
+                    warn("Data inválida em material '" + raw + "'.");
+                    return null;
+                }
+            }
+        }
+
+        Optional<XMaterial> matched = matchMaterial(materialName);
+        if (!matched.isPresent()) {
+            // Retry with data embedded for XMaterial (WOOL:14 style already handled by XMaterial)
+            if (data != null) {
+                matched = matchMaterial(materialName + ":" + data);
+            }
+        }
+
+        if (!matched.isPresent()) {
+            warn("Material desconhecido (ignorado nesta versão): " + raw);
+            return null;
+        }
+
+        XMaterial xMaterial = matched.get();
+        if (!xMaterial.isSupported()) {
+            warn("Material não suportado nesta versão do Minecraft: " + raw);
+            return null;
+        }
+
+        return new MaterialData(xMaterial, ignoreData ? null : data, ignoreData);
+    }
+
+    public static ItemStack create(String materialName, int data) {
+        MaterialData materialData = parseMaterialData(data > 0 ? materialName + ":" + data : materialName);
+        if (materialData == null) {
+            // Try plain name + separate data for legacy configs
+            Optional<XMaterial> matched = matchMaterial(materialName);
+            if (!matched.isPresent() || !matched.get().isSupported()) {
+                warn("Não foi possível criar o item: " + materialName + (data > 0 ? ":" + data : ""));
+                return fallbackBarrier();
+            }
+            materialData = new MaterialData(matched.get(), data > 0 ? data : null, data <= 0);
+        }
+        ItemStack stack = materialData.toItemStack(1);
+        return stack != null ? stack : fallbackBarrier();
+    }
+
+    public static ItemStack create(String materialName) {
+        return create(materialName, 0);
+    }
+
+    public static ItemStack named(ItemStack itemStack, String displayName, List<String> lore) {
+        if (itemStack == null) return null;
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) return itemStack;
+
+        if (displayName != null) {
+            meta.setDisplayName(displayName);
+        }
+        if (lore != null) {
+            meta.setLore(lore);
+        }
+        applySafeFlags(meta);
+        itemStack.setItemMeta(meta);
+        return itemStack;
+    }
+
+    public static ItemStack named(ItemStack itemStack, String displayName, String... lore) {
+        return named(itemStack, displayName, lore == null ? Collections.<String>emptyList() : Arrays.asList(lore));
+    }
+
+    public static void applyGlow(ItemStack itemStack) {
+        if (itemStack == null) return;
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) return;
+
+        Enchantment enchantment = resolveGlowEnchantment();
+        if (enchantment != null) {
+            meta.addEnchant(enchantment, 1, true);
+        }
+        applySafeFlags(meta);
+        itemStack.setItemMeta(meta);
+    }
+
+    public static void applySafeFlags(ItemMeta meta) {
+        if (meta == null) return;
+        // Avoid ItemFlag.values() — new flags on modern versions can break older items/APIs.
+        try {
+            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS);
+        } catch (Throwable ignored) {
+            try {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } catch (Throwable ignored2) {
+            }
+        }
+    }
+
+    public static Enchantment resolveGlowEnchantment() {
+        try {
+            Enchantment unbreaking = XEnchantment.UNBREAKING.get();
+            if (unbreaking != null) return unbreaking;
+        } catch (Throwable ignored) {
+        }
+
+        try {
+            Optional<XEnchantment> durability = XEnchantment.of("DURABILITY");
+            if (durability.isPresent()) {
+                Enchantment enchantment = durability.get().get();
+                if (enchantment != null) return enchantment;
+            }
+        } catch (Throwable ignored) {
+        }
+
+        Enchantment[] values = Enchantment.values();
+        return values.length > 0 ? values[0] : null;
+    }
+
+    public static ItemStack fallbackBarrier() {
+        Optional<XMaterial> barrier = matchMaterial("BARRIER");
+        if (barrier.isPresent() && barrier.get().isSupported()) {
+            ItemStack stack = barrier.get().parseItem();
+            if (stack != null) return stack;
+        }
+        Optional<XMaterial> bedrock = matchMaterial("BEDROCK");
+        if (bedrock.isPresent() && bedrock.get().isSupported()) {
+            ItemStack stack = bedrock.get().parseItem();
+            if (stack != null) return stack;
+        }
+        return new ItemStack(Material.STONE);
+    }
+
+    private static void warn(String message) {
+        try {
+            Logger logger = NextMarket.getInstance().getLogger();
+            logger.warning(message);
+        } catch (Throwable ignored) {
+            // Plugin may not be fully enabled yet
+        }
+    }
+
+}

--- a/src/main/java/com/nextplugins/nextmarket/compat/PlayerHands.java
+++ b/src/main/java/com/nextplugins/nextmarket/compat/PlayerHands.java
@@ -1,0 +1,60 @@
+package com.nextplugins.nextmarket.compat;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+import java.lang.reflect.Method;
+
+/**
+ * Main-hand helpers that work on 1.8 ({@code getItemInHand}) and 1.9+ ({@code getItemInMainHand}).
+ */
+public final class PlayerHands {
+
+    private static final Method GET_MAIN_HAND;
+    private static final Method SET_MAIN_HAND;
+
+    static {
+        Method get = null;
+        Method set = null;
+        try {
+            get = PlayerInventory.class.getMethod("getItemInMainHand");
+            set = PlayerInventory.class.getMethod("setItemInMainHand", ItemStack.class);
+        } catch (NoSuchMethodException ignored) {
+            // 1.8
+        }
+        GET_MAIN_HAND = get;
+        SET_MAIN_HAND = set;
+    }
+
+    private PlayerHands() {
+    }
+
+    public static ItemStack getMainHand(Player player) {
+        PlayerInventory inventory = player.getInventory();
+        if (GET_MAIN_HAND != null) {
+            try {
+                return (ItemStack) GET_MAIN_HAND.invoke(inventory);
+            } catch (ReflectiveOperationException ignored) {
+            }
+        }
+        return player.getItemInHand();
+    }
+
+    public static void setMainHand(Player player, ItemStack itemStack) {
+        PlayerInventory inventory = player.getInventory();
+        if (SET_MAIN_HAND != null) {
+            try {
+                SET_MAIN_HAND.invoke(inventory, itemStack);
+                return;
+            } catch (ReflectiveOperationException ignored) {
+            }
+        }
+        player.setItemInHand(itemStack);
+    }
+
+    public static void clearMainHand(Player player) {
+        setMainHand(player, null);
+    }
+
+}

--- a/src/main/java/com/nextplugins/nextmarket/compat/ServerVersion.java
+++ b/src/main/java/com/nextplugins/nextmarket/compat/ServerVersion.java
@@ -1,0 +1,100 @@
+package com.nextplugins.nextmarket.compat;
+
+import org.bukkit.Bukkit;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects the running Minecraft server version without relying on NMS package names
+ * (which Paper no longer exposes on modern builds).
+ */
+public final class ServerVersion {
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?");
+
+    private static final int MAJOR;
+    private static final int MINOR;
+    private static final int PATCH;
+    private static final boolean LEGACY;
+
+    static {
+        int major = 1;
+        int minor = 0;
+        int patch = 0;
+
+        String raw = Bukkit.getBukkitVersion();
+        if (raw == null || raw.isEmpty()) {
+            raw = Bukkit.getVersion();
+        }
+
+        // Prefer the part before '-' (e.g. "1.20.4-R0.1-SNAPSHOT" or "26.2-R0.1-SNAPSHOT")
+        String candidate = raw;
+        int dash = raw.indexOf('-');
+        if (dash > 0) {
+            candidate = raw.substring(0, dash);
+        }
+
+        Matcher matcher = VERSION_PATTERN.matcher(candidate);
+        if (matcher.find()) {
+            major = parse(matcher.group(1), 1);
+            minor = parse(matcher.group(2), 0);
+            patch = parse(matcher.group(3), 0);
+        } else {
+            // Fallback: scan full version string
+            matcher = VERSION_PATTERN.matcher(raw);
+            if (matcher.find()) {
+                major = parse(matcher.group(1), 1);
+                minor = parse(matcher.group(2), 0);
+                patch = parse(matcher.group(3), 0);
+            }
+        }
+
+        MAJOR = major;
+        MINOR = minor;
+        PATCH = patch;
+        // Pre-1.13 uses durability / data values. Year-based versions (26.x) are never legacy.
+        LEGACY = MAJOR == 1 && MINOR < 13;
+    }
+
+    private ServerVersion() {
+    }
+
+    private static int parse(String value, int fallback) {
+        if (value == null) return fallback;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    public static int major() {
+        return MAJOR;
+    }
+
+    public static int minor() {
+        return MINOR;
+    }
+
+    public static int patch() {
+        return PATCH;
+    }
+
+    /** True for Minecraft 1.8 – 1.12.x (material data / durability era). */
+    public static boolean isLegacy() {
+        return LEGACY;
+    }
+
+    public static boolean isAtLeast(int major, int minor) {
+        if (MAJOR != major) {
+            return MAJOR > major;
+        }
+        return MINOR >= minor;
+    }
+
+    public static String asString() {
+        return MAJOR + "." + MINOR + "." + PATCH;
+    }
+
+}

--- a/src/main/java/com/nextplugins/nextmarket/compat/Skulls.java
+++ b/src/main/java/com/nextplugins/nextmarket/compat/Skulls.java
@@ -1,0 +1,86 @@
+package com.nextplugins.nextmarket.compat;
+
+import com.cryptomorin.xseries.XMaterial;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * Player head helpers for SKULL_ITEM (1.8–1.12) and PLAYER_HEAD (1.13+).
+ */
+public final class Skulls {
+
+    private static final Method SET_OWNING_PLAYER;
+
+    static {
+        Method method = null;
+        try {
+            method = SkullMeta.class.getMethod("setOwningPlayer", org.bukkit.OfflinePlayer.class);
+        } catch (NoSuchMethodException ignored) {
+            // pre-1.12.1
+        }
+        SET_OWNING_PLAYER = method;
+    }
+
+    private Skulls() {
+    }
+
+    public static ItemStack createPlayerHead() {
+        Optional<XMaterial> head = XMaterial.matchXMaterial("PLAYER_HEAD");
+        if (head.isPresent() && head.get().isSupported()) {
+            ItemStack stack = head.get().parseItem();
+            if (stack != null) return stack;
+        }
+
+        Optional<XMaterial> skull = XMaterial.matchXMaterial("SKULL_ITEM");
+        if (skull.isPresent() && skull.get().isSupported()) {
+            ItemStack stack = skull.get().parseItem();
+            if (stack != null) return stack;
+        }
+
+        // Legacy data value 3 = player skull
+        return Items.create("SKULL_ITEM", 3);
+    }
+
+    public static ItemStack withOwner(ItemStack itemStack, String playerName) {
+        if (itemStack == null || playerName == null) return itemStack;
+
+        ItemMeta meta = itemStack.getItemMeta();
+        if (!(meta instanceof SkullMeta)) {
+            // Material might not be a skull on this version — try converting
+            ItemStack head = createPlayerHead();
+            head.setItemMeta(itemStack.getItemMeta());
+            meta = head.getItemMeta();
+            itemStack = head;
+        }
+
+        if (!(meta instanceof SkullMeta)) {
+            return itemStack;
+        }
+
+        SkullMeta skullMeta = (SkullMeta) meta;
+        if (SET_OWNING_PLAYER != null) {
+            try {
+                org.bukkit.OfflinePlayer offlinePlayer = org.bukkit.Bukkit.getOfflinePlayer(playerName);
+                SET_OWNING_PLAYER.invoke(skullMeta, offlinePlayer);
+            } catch (Throwable t) {
+                skullMeta.setOwner(playerName);
+            }
+        } else {
+            skullMeta.setOwner(playerName);
+        }
+
+        itemStack.setItemMeta(skullMeta);
+        return itemStack;
+    }
+
+    public static boolean isSkull(ItemStack itemStack) {
+        if (itemStack == null) return false;
+        String name = itemStack.getType().name();
+        return name.contains("SKULL") || name.contains("HEAD") && name.contains("PLAYER");
+    }
+
+}

--- a/src/main/java/com/nextplugins/nextmarket/inventory/CategoryInventory.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/CategoryInventory.java
@@ -1,141 +1,120 @@
 package com.nextplugins.nextmarket.inventory;
 
 import com.google.inject.Inject;
-import com.henryfabio.minecraft.inventoryapi.editor.InventoryEditor;
-import com.henryfabio.minecraft.inventoryapi.event.impl.CustomInventoryClickEvent;
-import com.henryfabio.minecraft.inventoryapi.inventory.impl.paged.PagedInventory;
-import com.henryfabio.minecraft.inventoryapi.item.InventoryItem;
-import com.henryfabio.minecraft.inventoryapi.item.enums.DefaultItem;
-import com.henryfabio.minecraft.inventoryapi.item.supplier.InventoryItemSupplier;
-import com.henryfabio.minecraft.inventoryapi.viewer.Viewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.configuration.impl.ViewerConfigurationImpl;
-import com.henryfabio.minecraft.inventoryapi.viewer.impl.paged.PagedViewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.property.ViewerPropertyMap;
 import com.nextplugins.nextmarket.NextMarket;
 import com.nextplugins.nextmarket.api.event.ProductBuyEvent;
 import com.nextplugins.nextmarket.api.event.ProductRemoveEvent;
 import com.nextplugins.nextmarket.api.model.category.Category;
-import com.nextplugins.nextmarket.api.model.category.CategoryIcon;
-import com.nextplugins.nextmarket.api.model.product.MaterialData;
 import com.nextplugins.nextmarket.api.model.product.Product;
+import com.nextplugins.nextmarket.compat.Items;
 import com.nextplugins.nextmarket.configuration.value.InventoryValue;
 import com.nextplugins.nextmarket.inventory.button.InventoryButton;
+import com.nextplugins.nextmarket.inventory.menu.PagedMarketMenu;
 import com.nextplugins.nextmarket.registry.InventoryButtonRegistry;
 import com.nextplugins.nextmarket.registry.InventoryRegistry;
 import com.nextplugins.nextmarket.storage.ProductStorage;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public final class CategoryInventory extends PagedInventory {
+public final class CategoryInventory {
 
     @Inject private ProductStorage productStorage;
     @Inject private InventoryRegistry inventoryRegistry;
     @Inject private InventoryButtonRegistry inventoryButtonRegistry;
 
     public CategoryInventory() {
-        super(
-                "market.category",
-                "",
-                InventoryValue.get(InventoryValue::categoryInventoryLines) * 9
-        );
-
         NextMarket.getInstance().getInjector().injectMembers(this);
-        configuration(configuration -> configuration.secondUpdate(1));
     }
 
-    @Override
-    protected void configureViewer(PagedViewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        Category category = propertyMap.get("category");
-
-        ViewerConfigurationImpl.Paged configuration = viewer.getConfiguration();
-        configuration.titleInventory(category.getConfiguration().getInventoryTitle());
-        configuration.backInventory("market.main");
-
-        configuration.nextPageSlot(53);
-        configuration.previousPageSlot(45);
-    }
-
-    @Override
-    protected void configureInventory(Viewer viewer, InventoryEditor editor) {
-        editor.setItem(48, DefaultItem.BACK.toInventoryItem(viewer));
-        editor.setItem(49, updateInventoryItem(viewer));
-    }
-
-    @Override
-    protected void update(PagedViewer viewer, InventoryEditor editor) {
-        updateCategoryItems(viewer);
-    }
-
-    @Override
-    protected List<InventoryItemSupplier> createPageItems(PagedViewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        Set<Product> products = propertyMap.get("products");
-
-        List<InventoryItemSupplier> itemSuppliers = new LinkedList<>();
-        for (Product product : products) {
-            itemSuppliers.add(() -> productInventoryItem(viewer, product));
+    public void openInventory(Player player, Category category, Set<Product> products) {
+        String title = category.getConfiguration().getInventoryTitle();
+        if (title == null || title.isEmpty()) {
+            title = InventoryValue.get(InventoryValue::categoryInventoryTitle)
+                    .replace("%category_name%", category.getDisplayName());
         }
-        return itemSuppliers;
-    }
+        int size = InventoryValue.get(InventoryValue::categoryInventoryLines) * 9;
 
-    private InventoryItem productInventoryItem(Viewer viewer, Product product) {
-        return InventoryItem.of(product.toViewItemStack((
-                product.getSeller().getName().equalsIgnoreCase(viewer.getName()) ?
-                        InventoryValue.get(InventoryValue::sellingInventoryItemLore) :
-                        InventoryValue.get(InventoryValue::categoryInventoryItemLore)))
-        ).defaultCallback(event -> {
-            Player player = event.getPlayer();
-            boolean itemCollect = product.getSeller().getUniqueId().equals(player.getUniqueId());
+        new PagedMarketMenu(title, size) {
+            @Override
+            protected void collectItems(Player viewer, List<PageItem> items) {
+                Set<Product> current = productStorage.findProductsByCategory(category);
+                if (current == null) return;
 
-            inventoryRegistry.getConfirmationInventory().openConfirmation(player,
-                    itemCollect ? "Recolher item" : "Comprar item",
-                    () -> {
-                        if (product.getSeller().getUniqueId().equals(player.getUniqueId())) {
-                            ProductRemoveEvent removeEvent = new ProductRemoveEvent(player, product);
-                            Bukkit.getPluginManager().callEvent(removeEvent);
-                        } else {
-                            ProductBuyEvent buyEvent = new ProductBuyEvent(player, product);
-                            Bukkit.getPluginManager().callEvent(buyEvent);
-                        }
-                        event.updateInventory();
-                    });
-        });
-    }
+                for (Product product : new ArrayList<Product>(current)) {
+                    if (product == null || !product.isAvailable()) continue;
 
-    private InventoryItem updateInventoryItem(Viewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        Category category = propertyMap.get("category");
+                    ItemStack view = product.toViewItemStack(
+                            product.getSeller().getName() != null
+                                    && product.getSeller().getName().equalsIgnoreCase(viewer.getName())
+                                    ? InventoryValue.get(InventoryValue::sellingInventoryItemLore)
+                                    : InventoryValue.get(InventoryValue::categoryInventoryItemLore)
+                    );
 
-        InventoryButton inventoryButton = inventoryButtonRegistry.get("category.update");
-        ItemStack itemStack = inventoryButton.getItemStack().clone();
+                    items.add(new PageItem(view, event -> {
+                        Player clicker = (Player) event.getWhoClicked();
+                        boolean itemCollect = product.getSeller().getUniqueId().equals(clicker.getUniqueId());
 
-        if (itemStack.getType() == Material.BARRIER) {
-            CategoryIcon categoryIcon = category.getIcon();
-
-            MaterialData materialData = categoryIcon.getMaterialData();
-            itemStack.setType(materialData.getMaterial());
-            itemStack.setDurability((short) materialData.getData());
-
-            if (categoryIcon.isEnchant() && Enchantment.DURABILITY.canEnchantItem(itemStack)) {
-                itemStack.addEnchantment(Enchantment.DURABILITY, 1);
+                        inventoryRegistry.getConfirmationInventory().openConfirmation(
+                                clicker,
+                                itemCollect ? "Recolher item" : "Comprar item",
+                                () -> {
+                                    if (product.getSeller().getUniqueId().equals(clicker.getUniqueId())) {
+                                        ProductRemoveEvent removeEvent = new ProductRemoveEvent(clicker, product);
+                                        Bukkit.getPluginManager().callEvent(removeEvent);
+                                    } else {
+                                        ProductBuyEvent buyEvent = new ProductBuyEvent(clicker, product);
+                                        Bukkit.getPluginManager().callEvent(buyEvent);
+                                    }
+                                    refresh();
+                                }
+                        );
+                    }));
+                }
             }
-        }
 
-        return InventoryItem.of(itemStack)
-                .defaultCallback(CustomInventoryClickEvent::updateInventory);
-    }
+            @Override
+            protected void onBack(InventoryClickEvent event) {
+                Player clicker = (Player) event.getWhoClicked();
+                inventoryRegistry.getMarketInventory().openInventory(clicker);
+            }
 
-    private void updateCategoryItems(Viewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        propertyMap.set("products", productStorage.findProductsByCategory(propertyMap.get("category")));
+            @Override
+            protected ItemStack createUpdateItem(Player viewer) {
+                InventoryButton inventoryButton = inventoryButtonRegistry.get("category.update");
+                if (inventoryButton == null) {
+                    return super.createUpdateItem(viewer);
+                }
+
+                ItemStack itemStack = inventoryButton.getItemStack().clone();
+                if (itemStack.getType().name().equals("BARRIER")) {
+                    ItemStack icon = category.getIcon().getMaterialData().toItemStack(1);
+                    ItemMeta meta = itemStack.getItemMeta();
+                    itemStack = icon;
+                    if (meta != null) {
+                        ItemMeta iconMeta = itemStack.getItemMeta();
+                        if (iconMeta != null) {
+                            if (meta.hasDisplayName()) iconMeta.setDisplayName(meta.getDisplayName());
+                            if (meta.hasLore()) iconMeta.setLore(meta.getLore());
+                            if (category.getIcon().isEnchant()) {
+                                org.bukkit.enchantments.Enchantment glow = Items.resolveGlowEnchantment();
+                                if (glow != null) iconMeta.addEnchant(glow, 1, true);
+                            }
+                            Items.applySafeFlags(iconMeta);
+                            itemStack.setItemMeta(iconMeta);
+                        }
+                    }
+                }
+                return itemStack;
+            }
+
+        }.open(player);
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/inventory/ConfirmationInventory.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/ConfirmationInventory.java
@@ -1,34 +1,84 @@
 package com.nextplugins.nextmarket.inventory;
 
-import com.henryfabio.minecraft.inventoryapi.editor.InventoryEditor;
-import com.henryfabio.minecraft.inventoryapi.inventory.impl.simple.SimpleInventory;
-import com.henryfabio.minecraft.inventoryapi.item.InventoryItem;
-import com.henryfabio.minecraft.inventoryapi.viewer.Viewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.configuration.ViewerConfiguration;
-import com.henryfabio.minecraft.inventoryapi.viewer.impl.simple.SimpleViewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.property.ViewerPropertyMap;
-import com.nextplugins.nextmarket.util.TypeUtil;
+import com.nextplugins.nextmarket.compat.Items;
+import com.nextplugins.nextmarket.inventory.menu.MarketMenu;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.Arrays;
 
-public final class ConfirmationInventory extends SimpleInventory {
-
-    public ConfirmationInventory() {
-        super("nextmarket.confirmation", "§8Confirmação", 3 * 9);
-    }
+public final class ConfirmationInventory {
 
     public void openConfirmation(Player player, String description, Runnable confirm, Runnable decline, ItemStack itemStack) {
-        openInventory(player, viewer -> {
-            ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-            propertyMap.set("description", description);
-            propertyMap.set("confirm", confirm);
-            propertyMap.set("decline", decline);
-            propertyMap.set("itemStack", itemStack);
-        });
+        final String safeDescription = description == null ? "Confirmação" : description;
+        final boolean hasPreview = itemStack != null;
+        int size = (hasPreview ? 4 : 3) * 9;
+        String title = ("§8" + safeDescription);
+        if (title.length() > 32) {
+            title = title.substring(0, 32);
+        }
+
+        new MarketMenu(title, size) {
+            @Override
+            protected void render(Player viewer) {
+                int increment = hasPreview ? 9 : 0;
+
+                if (hasPreview) {
+                    setItem(13, itemStack.clone());
+                }
+
+                ItemStack confirmItem = Items.named(
+                        Items.create("LIME_TERRACOTTA"),
+                        "§aConfirmar",
+                        Arrays.asList(
+                                "§7Clique para confirmar esta ação!",
+                                "§c§lOBS: §cEsta opção é irreversível!"
+                        )
+                );
+                // Fallback for 1.8 stained clay
+                if (confirmItem.getType().name().equals("STONE") || confirmItem.getType().name().contains("BARRIER")) {
+                    confirmItem = Items.named(
+                            Items.create("STAINED_CLAY", 13),
+                            "§aConfirmar",
+                            Arrays.asList(
+                                    "§7Clique para confirmar esta ação!",
+                                    "§c§lOBS: §cEsta opção é irreversível!"
+                            )
+                    );
+                }
+
+                ItemStack declineItem = Items.named(
+                        Items.create("RED_TERRACOTTA"),
+                        "§cCancelar",
+                        Arrays.asList(
+                                "§7Clique para cancelar esta ação!",
+                                "§c§lOBS: §cEsta opção é irreversível!"
+                        )
+                );
+                if (declineItem.getType().name().equals("STONE") || declineItem.getType().name().contains("BARRIER")) {
+                    declineItem = Items.named(
+                            Items.create("STAINED_CLAY", 14),
+                            "§cCancelar",
+                            Arrays.asList(
+                                    "§7Clique para cancelar esta ação!",
+                                    "§c§lOBS: §cEsta opção é irreversível!"
+                            )
+                    );
+                }
+
+                setItem(11 + increment, confirmItem, event -> {
+                    Player clicker = (Player) event.getWhoClicked();
+                    clicker.closeInventory();
+                    if (confirm != null) confirm.run();
+                });
+
+                setItem(15 + increment, declineItem, event -> {
+                    Player clicker = (Player) event.getWhoClicked();
+                    clicker.closeInventory();
+                    if (decline != null) decline.run();
+                });
+            }
+        }.open(player);
     }
 
     public void openConfirmation(Player player, String description, Runnable confirm, ItemStack itemStack) {
@@ -37,71 +87,6 @@ public final class ConfirmationInventory extends SimpleInventory {
 
     public void openConfirmation(Player player, String description, Runnable confirm) {
         openConfirmation(player, description, confirm, null, null);
-    }
-
-    @Override
-    protected void configureViewer(SimpleViewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        String description = propertyMap.get("description");
-        ItemStack itemStack = propertyMap.get("itemStack");
-
-        ViewerConfiguration configuration = viewer.getConfiguration();
-        configuration.titleInventory(("§8" + description).substring(0, Math.min(32, description.length() + 2)));
-        configuration.inventorySize((itemStack == null ? 3 : 4) * 9);
-    }
-
-    @Override
-    protected void configureInventory(Viewer viewer, InventoryEditor editor) {
-        ItemStack itemStack = viewer.getPropertyMap().get("itemStack");
-        int increment = itemStack != null ? 9 : 0;
-
-        editor.setItem(11 + increment, confirmInventoryItem());
-        editor.setItem(15 + increment, declineInventoryItem());
-
-        if (itemStack != null) {
-            editor.setItem(13, InventoryItem.of(itemStack));
-        }
-    }
-
-    private InventoryItem confirmInventoryItem() {
-
-        ItemStack itemStack = TypeUtil.convertFromLegacy("STAINED_CLAY", 13);
-
-        ItemMeta itemMeta = itemStack.getItemMeta();
-        itemMeta.setDisplayName("§aConfirmar");
-        itemMeta.setLore(Arrays.asList(
-                "§7Clique para confirmar esta ação!",
-                "§c§lOBS: §cEsta opção é irreversível!"
-        ));
-        itemMeta.addItemFlags(ItemFlag.values());
-        itemStack.setItemMeta(itemMeta);
-
-        return InventoryItem.of(itemStack)
-                .defaultCallback(event -> acceptRunnable(event.getViewer(), "confirm"));
-    }
-
-    private InventoryItem declineInventoryItem() {
-        ItemStack itemStack = TypeUtil.convertFromLegacy("STAINED_CLAY", 14);
-
-        ItemMeta itemMeta = itemStack.getItemMeta();
-        itemMeta.setDisplayName("§aCancelar");
-        itemMeta.setLore(Arrays.asList(
-                "§7Clique para cancelar esta ação!",
-                "§c§lOBS: §cEsta opção é irreversível!"
-        ));
-        itemMeta.addItemFlags(ItemFlag.values());
-        itemStack.setItemMeta(itemMeta);
-
-        return InventoryItem.of(itemStack)
-                .defaultCallback(event -> acceptRunnable(event.getViewer(), "decline"));
-    }
-
-    private void acceptRunnable(Viewer viewer, String property) {
-        Player player = viewer.getPlayer();
-        player.closeInventory();
-
-        Runnable runnable = viewer.getPropertyMap().get(property);
-        if (runnable != null) runnable.run();
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/inventory/MarketInventory.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/MarketInventory.java
@@ -1,25 +1,20 @@
 package com.nextplugins.nextmarket.inventory;
 
 import com.google.inject.Inject;
-import com.henryfabio.minecraft.inventoryapi.editor.InventoryEditor;
-import com.henryfabio.minecraft.inventoryapi.inventory.impl.simple.SimpleInventory;
-import com.henryfabio.minecraft.inventoryapi.item.InventoryItem;
-import com.henryfabio.minecraft.inventoryapi.viewer.Viewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.property.ViewerPropertyMap;
 import com.nextplugins.nextmarket.NextMarket;
 import com.nextplugins.nextmarket.api.model.category.Category;
-import com.nextplugins.nextmarket.api.model.product.MaterialData;
 import com.nextplugins.nextmarket.api.model.product.Product;
+import com.nextplugins.nextmarket.compat.Items;
+import com.nextplugins.nextmarket.compat.ServerVersion;
 import com.nextplugins.nextmarket.configuration.value.InventoryValue;
 import com.nextplugins.nextmarket.inventory.button.InventoryButton;
+import com.nextplugins.nextmarket.inventory.menu.MarketMenu;
 import com.nextplugins.nextmarket.manager.CategoryManager;
 import com.nextplugins.nextmarket.registry.InventoryButtonRegistry;
 import com.nextplugins.nextmarket.registry.InventoryRegistry;
 import com.nextplugins.nextmarket.storage.ProductStorage;
-import com.nextplugins.nextmarket.util.VersionUtils;
 import org.bukkit.ChatColor;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemFlag;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -28,101 +23,100 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-public final class MarketInventory extends SimpleInventory {
+public final class MarketInventory {
 
     @Inject private CategoryManager categoryManager;
     @Inject private ProductStorage productStorage;
-
     @Inject private InventoryRegistry inventoryRegistry;
     @Inject private InventoryButtonRegistry inventoryButtonRegistry;
 
     public MarketInventory() {
-        super(
-                "market.main",
-                InventoryValue.get(InventoryValue::mainInventoryTitle),
-                InventoryValue.get(InventoryValue::mainInventoryLines) * 9
-        );
-
         NextMarket.getInstance().getInjector().injectMembers(this);
     }
 
-    @Override
-    protected void configureInventory(Viewer viewer, InventoryEditor editor) {
+    public void openInventory(Player player) {
+        String title = InventoryValue.get(InventoryValue::mainInventoryTitle);
+        int size = InventoryValue.get(InventoryValue::mainInventoryLines) * 9;
 
-        Map<Category, Set<Product>> allProducts = productStorage.getProducts();
-        for (Category category : categoryManager.getCategoryMap().values()) {
-            Set<Product> products = new LinkedHashSet<>(allProducts.getOrDefault(category, Collections.emptySet()));
-            products.removeIf(product -> product.getDestination() != null || product.isExpired());
-            editor.setItem(
-                    category.getIcon().getInventorySlot(),
-                    categoryInventoryItem(category, products)
-            );
-        }
+        new MarketMenu(title, size) {
+            @Override
+            protected void render(Player viewer) {
+                Map<Category, Set<Product>> allProducts = productStorage.getProducts();
+                for (Category category : categoryManager.getCategoryMap().values()) {
+                    Set<Product> products = new LinkedHashSet<Product>(
+                            allProducts.getOrDefault(category, Collections.<Product>emptySet())
+                    );
+                    products.removeIf(product -> product.getDestination() != null || product.isExpired());
 
-        InventoryButton personalMarketButton = inventoryButtonRegistry.get("main.personalMarket");
-        editor.setItem(personalMarketButton.getInventorySlot(), personalMarketInventoryItem(personalMarketButton));
+                    setItem(
+                            category.getIcon().getInventorySlot(),
+                            categoryItemStack(category, products),
+                            event -> openCategory(event.getWhoClicked() instanceof Player
+                                    ? (Player) event.getWhoClicked()
+                                    : viewer, category, products)
+                    );
+                }
 
-        InventoryButton sellingMarketButton = inventoryButtonRegistry.get("main.sellingMarket");
-        editor.setItem(sellingMarketButton.getInventorySlot(), sellingMarketInventoryItem(sellingMarketButton));
+                InventoryButton personalMarketButton = inventoryButtonRegistry.get("main.personalMarket");
+                if (personalMarketButton != null) {
+                    setItem(personalMarketButton.getInventorySlot(), personalMarketButton.getItemStack(), event -> {
+                        Player clicker = (Player) event.getWhoClicked();
+                        try {
+                            inventoryRegistry.getPersonalMarketInventory().openInventory(clicker);
+                        } catch (Throwable ignored) {
+                            clicker.closeInventory();
+                            clicker.sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
+                        }
+                    });
+                }
+
+                InventoryButton sellingMarketButton = inventoryButtonRegistry.get("main.sellingMarket");
+                if (sellingMarketButton != null) {
+                    setItem(sellingMarketButton.getInventorySlot(), sellingMarketButton.getItemStack(), event -> {
+                        Player clicker = (Player) event.getWhoClicked();
+                        try {
+                            inventoryRegistry.getSellingMarketInventory().openInventory(clicker);
+                        } catch (Throwable ignored) {
+                            clicker.closeInventory();
+                            clicker.sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
+                        }
+                    });
+                }
+            }
+        }.open(player);
     }
 
-    private InventoryItem categoryInventoryItem(Category category, Set<Product> products) {
-        return InventoryItem.of(categoryItemStack(category, products)).defaultCallback(event -> {
-            try {
-                inventoryRegistry.getCategoryInventory().openInventory(event.getPlayer(), viewer -> {
-                    ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-                    propertyMap.set("category", category);
-                    propertyMap.set("products", products);
-                });
-            } catch (Throwable ignored) {
-                event.getPlayer().closeInventory();
-                event.getPlayer().sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
-            }
-        });
+    private void openCategory(Player player, Category category, Set<Product> products) {
+        try {
+            inventoryRegistry.getCategoryInventory().openInventory(player, category, products);
+        } catch (Throwable ignored) {
+            player.closeInventory();
+            player.sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
+        }
     }
 
     private ItemStack categoryItemStack(Category category, Set<Product> products) {
-        MaterialData materialData = category.getIcon().getMaterialData();
-        ItemStack itemStack = new ItemStack(materialData.getMaterial(),
-                VersionUtils.isLegacy() ? Math.min(products.size(), 64) : 1,
-                (short) materialData.getData());
+        ItemStack itemStack = category.getIcon().getMaterialData().toItemStack(
+                ServerVersion.isLegacy() ? Math.max(1, Math.min(products.size(), 64)) : 1
+        );
 
         ItemMeta itemMeta = itemStack.getItemMeta();
-        itemMeta.setDisplayName(category.getDisplayName()
-                .replace("%amount%", String.valueOf(products.size()))
-        );
-        itemMeta.setLore(category.getDescription());
-        itemMeta.addItemFlags(ItemFlag.values());
-        if (category.getIcon().isEnchant()) {
-            itemMeta.addEnchant(Enchantment.DURABILITY, 1, true);
+        if (itemMeta != null) {
+            itemMeta.setDisplayName(category.getDisplayName()
+                    .replace("%amount%", String.valueOf(products.size()))
+            );
+            itemMeta.setLore(category.getDescription());
+            Items.applySafeFlags(itemMeta);
+            if (category.getIcon().isEnchant()) {
+                org.bukkit.enchantments.Enchantment glow = Items.resolveGlowEnchantment();
+                if (glow != null) {
+                    itemMeta.addEnchant(glow, 1, true);
+                }
+            }
+            itemStack.setItemMeta(itemMeta);
         }
-        itemStack.setItemMeta(itemMeta);
 
         return itemStack;
-    }
-
-    private InventoryItem personalMarketInventoryItem(InventoryButton inventoryButton) {
-        return InventoryItem.of(inventoryButton.getItemStack()).defaultCallback(event -> {
-            try {
-                PersonalMarketInventory personalMarketInventory = inventoryRegistry.getPersonalMarketInventory();
-                personalMarketInventory.openInventory(event.getPlayer());
-            } catch (Throwable ignored) {
-                event.getPlayer().closeInventory();
-                event.getPlayer().sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
-            }
-        });
-    }
-
-    private InventoryItem sellingMarketInventoryItem(InventoryButton inventoryButton) {
-        return InventoryItem.of(inventoryButton.getItemStack()).defaultCallback(event -> {
-            try {
-                SellingMarketInventory sellingMarketInventory = inventoryRegistry.getSellingMarketInventory();
-                sellingMarketInventory.openInventory(event.getPlayer());
-            } catch (Throwable ignored) {
-                event.getPlayer().closeInventory();
-                event.getPlayer().sendMessage(ChatColor.RED + "Não existe itens nesta categoria.");
-            }
-        });
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/inventory/PersonalMarketInventory.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/PersonalMarketInventory.java
@@ -1,104 +1,78 @@
 package com.nextplugins.nextmarket.inventory;
 
 import com.google.inject.Inject;
-import com.henryfabio.minecraft.inventoryapi.editor.InventoryEditor;
-import com.henryfabio.minecraft.inventoryapi.event.impl.CustomInventoryClickEvent;
-import com.henryfabio.minecraft.inventoryapi.inventory.impl.paged.PagedInventory;
-import com.henryfabio.minecraft.inventoryapi.item.InventoryItem;
-import com.henryfabio.minecraft.inventoryapi.item.enums.DefaultItem;
-import com.henryfabio.minecraft.inventoryapi.item.supplier.InventoryItemSupplier;
-import com.henryfabio.minecraft.inventoryapi.viewer.Viewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.configuration.impl.ViewerConfigurationImpl;
-import com.henryfabio.minecraft.inventoryapi.viewer.impl.paged.PagedViewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.property.ViewerPropertyMap;
 import com.nextplugins.nextmarket.NextMarket;
 import com.nextplugins.nextmarket.api.event.ProductBuyEvent;
 import com.nextplugins.nextmarket.api.model.product.Product;
 import com.nextplugins.nextmarket.configuration.value.InventoryValue;
 import com.nextplugins.nextmarket.inventory.button.InventoryButton;
+import com.nextplugins.nextmarket.inventory.menu.PagedMarketMenu;
 import com.nextplugins.nextmarket.registry.InventoryButtonRegistry;
 import com.nextplugins.nextmarket.registry.InventoryRegistry;
 import com.nextplugins.nextmarket.storage.ProductStorage;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public final class PersonalMarketInventory extends PagedInventory {
+public final class PersonalMarketInventory {
 
     @Inject private ProductStorage productStorage;
     @Inject private InventoryRegistry inventoryRegistry;
     @Inject private InventoryButtonRegistry inventoryButtonRegistry;
 
     public PersonalMarketInventory() {
-        super(
-                "market.personal",
-                InventoryValue.get(InventoryValue::privateInventoryTitle),
-                InventoryValue.get(InventoryValue::privateInventoryLines) * 9
-        );
-
         NextMarket.getInstance().getInjector().injectMembers(this);
-        configuration(configuration -> configuration.secondUpdate(5));
     }
 
-    @Override
-    protected void configureViewer(PagedViewer viewer) {
-        ViewerConfigurationImpl.Paged configuration = viewer.getConfiguration();
-        configuration.backInventory("market.main");
-    }
+    public void openInventory(Player player) {
+        String title = InventoryValue.get(InventoryValue::privateInventoryTitle);
+        int size = InventoryValue.get(InventoryValue::privateInventoryLines) * 9;
 
-    @Override
-    protected void configureInventory(Viewer viewer, InventoryEditor editor) {
-        editor.setItem(48, DefaultItem.BACK.toInventoryItem(viewer));
-        editor.setItem(49, updateInventoryItem(viewer));
-    }
+        new PagedMarketMenu(title, size) {
+            @Override
+            protected void collectItems(Player viewer, List<PageItem> items) {
+                Set<Product> products = productStorage.findProductsByDestination(viewer);
+                for (Product product : new ArrayList<Product>(products)) {
+                    if (product == null || product.isExpired() || !product.isAvailable()) continue;
 
-    @Override
-    protected void update(PagedViewer viewer, InventoryEditor editor) {
-        updateCategoryItems(viewer);
-    }
+                    ItemStack view = product.toViewItemStack(
+                            InventoryValue.get(InventoryValue::privateInventoryItemLore)
+                    );
 
-    @Override
-    protected List<InventoryItemSupplier> createPageItems(PagedViewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        Set<Product> products = propertyMap.get("products");
+                    items.add(new PageItem(view, event -> {
+                        Player clicker = (Player) event.getWhoClicked();
+                        inventoryRegistry.getConfirmationInventory().openConfirmation(
+                                clicker,
+                                "Comprar item",
+                                () -> {
+                                    ProductBuyEvent buyEvent = new ProductBuyEvent(clicker, product);
+                                    Bukkit.getPluginManager().callEvent(buyEvent);
+                                    refresh();
+                                }
+                        );
+                    }));
+                }
+            }
 
-        List<InventoryItemSupplier> itemSuppliers = new LinkedList<>();
-        for (Product product : products) {
-            if (product.isExpired()) continue;
-            itemSuppliers.add(() -> productInventoryItem(product));
-        }
-        return itemSuppliers;
-    }
+            @Override
+            protected void onBack(InventoryClickEvent event) {
+                inventoryRegistry.getMarketInventory().openInventory((Player) event.getWhoClicked());
+            }
 
-    private InventoryItem productInventoryItem(Product product) {
-        return InventoryItem.of(product.toViewItemStack(InventoryValue.get(InventoryValue::privateInventoryItemLore)))
-                .defaultCallback(event -> {
-                    Player player = event.getPlayer();
-                    inventoryRegistry.getConfirmationInventory().openConfirmation(player,
-                            "Comprar item",
-                            () -> {
-                                ProductBuyEvent buyEvent = new ProductBuyEvent(player, product);
-                                Bukkit.getPluginManager().callEvent(buyEvent);
-                                event.updateInventory();
-                            });
-                });
-    }
-
-    private InventoryItem updateInventoryItem(Viewer viewer) {
-        InventoryButton inventoryButton = inventoryButtonRegistry.get("personal.update");
-        ItemStack itemStack = inventoryButton.getSkullItemStack(viewer.getName());
-
-        return InventoryItem.of(itemStack)
-                .defaultCallback(CustomInventoryClickEvent::updateInventory);
-    }
-
-    private void updateCategoryItems(Viewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        propertyMap.set("products", productStorage.findProductsByDestination(viewer.getPlayer()));
+            @Override
+            protected ItemStack createUpdateItem(Player viewer) {
+                InventoryButton inventoryButton = inventoryButtonRegistry.get("personal.update");
+                if (inventoryButton == null) {
+                    return super.createUpdateItem(viewer);
+                }
+                return inventoryButton.getSkullItemStack(viewer.getName());
+            }
+        }.open(player);
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/inventory/SellingMarketInventory.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/SellingMarketInventory.java
@@ -1,122 +1,100 @@
 package com.nextplugins.nextmarket.inventory;
 
 import com.google.inject.Inject;
-import com.henryfabio.minecraft.inventoryapi.editor.InventoryEditor;
-import com.henryfabio.minecraft.inventoryapi.event.impl.CustomInventoryClickEvent;
-import com.henryfabio.minecraft.inventoryapi.inventory.impl.paged.PagedInventory;
-import com.henryfabio.minecraft.inventoryapi.item.InventoryItem;
-import com.henryfabio.minecraft.inventoryapi.item.enums.DefaultItem;
-import com.henryfabio.minecraft.inventoryapi.item.supplier.InventoryItemSupplier;
-import com.henryfabio.minecraft.inventoryapi.viewer.Viewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.configuration.impl.ViewerConfigurationImpl;
-import com.henryfabio.minecraft.inventoryapi.viewer.impl.paged.PagedViewer;
-import com.henryfabio.minecraft.inventoryapi.viewer.property.ViewerPropertyMap;
 import com.nextplugins.nextmarket.NextMarket;
 import com.nextplugins.nextmarket.api.event.ProductRemoveEvent;
 import com.nextplugins.nextmarket.api.model.product.Product;
 import com.nextplugins.nextmarket.configuration.value.InventoryValue;
 import com.nextplugins.nextmarket.inventory.button.InventoryButton;
+import com.nextplugins.nextmarket.inventory.menu.PagedMarketMenu;
 import com.nextplugins.nextmarket.registry.InventoryButtonRegistry;
 import com.nextplugins.nextmarket.registry.InventoryRegistry;
 import com.nextplugins.nextmarket.storage.ProductStorage;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-
-public final class SellingMarketInventory extends PagedInventory {
+public final class SellingMarketInventory {
 
     @Inject private ProductStorage productStorage;
     @Inject private InventoryRegistry inventoryRegistry;
     @Inject private InventoryButtonRegistry inventoryButtonRegistry;
 
     public SellingMarketInventory() {
-        super(
-                "market.selling",
-                InventoryValue.get(InventoryValue::sellingInventoryTitle),
-                InventoryValue.get(InventoryValue::sellingInventoryLines) * 9
-        );
-
         NextMarket.getInstance().getInjector().injectMembers(this);
-        configuration(configuration -> configuration.secondUpdate(5));
     }
 
-    @Override
-    protected void configureViewer(PagedViewer viewer) {
-        ViewerConfigurationImpl.Paged configuration = viewer.getConfiguration();
-        configuration.backInventory("market.main");
-    }
+    public void openInventory(Player player) {
+        String title = InventoryValue.get(InventoryValue::sellingInventoryTitle);
+        int size = InventoryValue.get(InventoryValue::sellingInventoryLines) * 9;
 
-    @Override
-    protected void configureInventory(Viewer viewer, InventoryEditor editor) {
-        editor.setItem(48, DefaultItem.BACK.toInventoryItem(viewer));
-        editor.setItem(49, updateInventoryItem(viewer));
-    }
+        new PagedMarketMenu(title, size) {
+            @Override
+            protected void collectItems(Player viewer, List<PageItem> items) {
+                Set<Product> products = productStorage.findProductsBySeller(viewer);
+                for (Product product : new ArrayList<Product>(products)) {
+                    if (product == null || !product.isAvailable()) continue;
 
-    @Override
-    protected void update(PagedViewer viewer, InventoryEditor editor) {
-        updateCategoryItems(viewer);
-    }
+                    ItemStack view = product.toViewItemStack(
+                            InventoryValue.get(InventoryValue::sellingInventoryItemLore)
+                    );
+                    if (product.isExpired()) {
+                        addExpiredTag(view);
+                    }
 
-    @Override
-    protected List<InventoryItemSupplier> createPageItems(PagedViewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        Set<Product> products = propertyMap.get("products");
+                    items.add(new PageItem(view, event -> {
+                        Player clicker = (Player) event.getWhoClicked();
+                        inventoryRegistry.getConfirmationInventory().openConfirmation(
+                                clicker,
+                                "Recolher item",
+                                () -> {
+                                    ProductRemoveEvent removeEvent = new ProductRemoveEvent(clicker, product);
+                                    Bukkit.getPluginManager().callEvent(removeEvent);
+                                    refresh();
+                                }
+                        );
+                    }));
+                }
+            }
 
-        List<InventoryItemSupplier> itemSuppliers = new LinkedList<>();
-        for (Product product : products) {
-            itemSuppliers.add(() -> productInventoryItem(product));
-        }
-        return itemSuppliers;
-    }
+            @Override
+            protected void onBack(InventoryClickEvent event) {
+                inventoryRegistry.getMarketInventory().openInventory((Player) event.getWhoClicked());
+            }
 
-    private InventoryItem productInventoryItem(Product product) {
-        ItemStack itemStack = product.toViewItemStack(InventoryValue.get(InventoryValue::sellingInventoryItemLore));
-
-        if (product.isExpired()) {
-            addExpiredTag(itemStack);
-        }
-
-        return InventoryItem.of(itemStack)
-                .defaultCallback(event -> {
-                    Player player = event.getPlayer();
-                    inventoryRegistry.getConfirmationInventory().openConfirmation(player,
-                            "Recolher item",
-                            () -> {
-                                ProductRemoveEvent removeEvent = new ProductRemoveEvent(player, product);
-                                Bukkit.getPluginManager().callEvent(removeEvent);
-                                event.updateInventory();
-                            });
-                });
-    }
-
-    private InventoryItem updateInventoryItem(Viewer viewer) {
-        InventoryButton inventoryButton = inventoryButtonRegistry.get("selling.update");
-        ItemStack itemStack = inventoryButton.getSkullItemStack(viewer.getName());
-
-        return InventoryItem.of(itemStack)
-                .defaultCallback(CustomInventoryClickEvent::updateInventory);
-    }
-
-    private void updateCategoryItems(Viewer viewer) {
-        ViewerPropertyMap propertyMap = viewer.getPropertyMap();
-        propertyMap.set("products", productStorage.findProductsBySeller(viewer.getPlayer()));
+            @Override
+            protected ItemStack createUpdateItem(Player viewer) {
+                InventoryButton inventoryButton = inventoryButtonRegistry.get("selling.update");
+                if (inventoryButton == null) {
+                    return super.createUpdateItem(viewer);
+                }
+                return inventoryButton.getSkullItemStack(viewer.getName());
+            }
+        }.open(player);
     }
 
     private void addExpiredTag(ItemStack itemStack) {
         String expiredTag = InventoryValue.get(InventoryValue::sellingExpiredTag);
-        if (!expiredTag.isEmpty()) {
-            ItemMeta itemMeta = itemStack.getItemMeta();
-            List<String> lore = itemMeta.getLore();
-            lore.add(expiredTag);
-            itemMeta.setLore(lore);
-            itemStack.setItemMeta(itemMeta);
+        if (expiredTag == null || expiredTag.isEmpty()) return;
+
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        if (itemMeta == null) return;
+
+        List<String> lore = itemMeta.getLore();
+        if (lore == null) {
+            lore = new ArrayList<String>();
+        } else {
+            lore = new ArrayList<String>(lore);
         }
+        lore.add(expiredTag);
+        itemMeta.setLore(lore);
+        itemStack.setItemMeta(itemMeta);
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/inventory/button/InventoryButton.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/button/InventoryButton.java
@@ -1,12 +1,12 @@
 package com.nextplugins.nextmarket.inventory.button;
 
 import com.nextplugins.nextmarket.api.model.product.MaterialData;
+import com.nextplugins.nextmarket.compat.Items;
+import com.nextplugins.nextmarket.compat.Skulls;
 import lombok.Builder;
 import lombok.Data;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.List;
 
@@ -25,26 +25,34 @@ public final class InventoryButton {
 
     public ItemStack getItemStack() {
         if (this.itemStack == null) {
-            this.itemStack = materialData.toItemStack(1);
+            this.itemStack = materialData != null
+                    ? materialData.toItemStack(1)
+                    : Items.fallbackBarrier();
             ItemMeta itemMeta = itemStack.getItemMeta();
-            itemMeta.setDisplayName(this.displayName);
-            itemMeta.setLore(this.lore);
-            itemMeta.addItemFlags(ItemFlag.values());
-            this.itemStack.setItemMeta(itemMeta);
+            if (itemMeta != null) {
+                if (this.displayName != null) {
+                    itemMeta.setDisplayName(this.displayName);
+                }
+                if (this.lore != null) {
+                    itemMeta.setLore(this.lore);
+                }
+                Items.applySafeFlags(itemMeta);
+                this.itemStack.setItemMeta(itemMeta);
+            }
         }
         return this.itemStack;
     }
 
     public ItemStack getSkullItemStack(String playerName) {
-        ItemStack itemStack = this.getItemStack().clone();
+        ItemStack base = this.getItemStack().clone();
+        ItemStack head = Skulls.createPlayerHead();
 
-        if (itemStack.getType().name().contains("SKULL_ITEM")) {
-            SkullMeta skullMeta = (SkullMeta) itemStack.getItemMeta();
-            skullMeta.setOwner(playerName);
-            itemStack.setItemMeta(skullMeta);
+        ItemMeta baseMeta = base.getItemMeta();
+        if (baseMeta != null) {
+            head.setItemMeta(baseMeta);
         }
 
-        return itemStack;
+        return Skulls.withOwner(head, playerName);
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/inventory/menu/MarketMenu.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/menu/MarketMenu.java
@@ -1,0 +1,96 @@
+package com.nextplugins.nextmarket.inventory.menu;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Lightweight cross-version menu based only on the Bukkit inventory API (1.8+).
+ */
+public abstract class MarketMenu implements InventoryHolder {
+
+    private final String title;
+    private final int size;
+    private final Map<Integer, Consumer<InventoryClickEvent>> clickHandlers = new HashMap<Integer, Consumer<InventoryClickEvent>>();
+
+    private Inventory inventory;
+    private Player viewer;
+
+    protected MarketMenu(String title, int size) {
+        this.title = truncateTitle(title);
+        this.size = normalizeSize(size);
+    }
+
+    private static int normalizeSize(int size) {
+        if (size < 9) return 9;
+        if (size > 54) return 54;
+        int rows = (int) Math.ceil(size / 9.0);
+        return rows * 9;
+    }
+
+    private static String truncateTitle(String title) {
+        if (title == null) return "";
+        // 1.8 inventory titles are limited to 32 characters
+        return title.length() > 32 ? title.substring(0, 32) : title;
+    }
+
+    public final void open(Player player) {
+        this.viewer = player;
+        this.clickHandlers.clear();
+        this.inventory = Bukkit.createInventory(this, size, this.title);
+        render(player);
+        player.openInventory(inventory);
+    }
+
+    /** Rebuild contents while keeping the inventory open. */
+    public final void refresh() {
+        if (viewer == null || inventory == null) return;
+        clickHandlers.clear();
+        inventory.clear();
+        render(viewer);
+    }
+
+    protected abstract void render(Player player);
+
+    protected void setItem(int slot, ItemStack itemStack) {
+        setItem(slot, itemStack, null);
+    }
+
+    protected void setItem(int slot, ItemStack itemStack, Consumer<InventoryClickEvent> handler) {
+        if (inventory == null || slot < 0 || slot >= inventory.getSize()) return;
+        inventory.setItem(slot, itemStack);
+        if (handler != null) {
+            clickHandlers.put(slot, handler);
+        } else {
+            clickHandlers.remove(slot);
+        }
+    }
+
+    protected void handleClick(InventoryClickEvent event) {
+        Consumer<InventoryClickEvent> handler = clickHandlers.get(event.getRawSlot());
+        if (handler != null) {
+            handler.accept(event);
+        }
+    }
+
+    protected Player getViewer() {
+        return viewer;
+    }
+
+    protected int getSize() {
+        return size;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+}

--- a/src/main/java/com/nextplugins/nextmarket/inventory/menu/MenuListener.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/menu/MenuListener.java
@@ -1,0 +1,40 @@
+package com.nextplugins.nextmarket.inventory.menu;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public final class MenuListener implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onClick(InventoryClickEvent event) {
+        Inventory top = event.getView().getTopInventory();
+        if (top == null) return;
+
+        InventoryHolder holder = top.getHolder();
+        if (!(holder instanceof MarketMenu)) return;
+
+        event.setCancelled(true);
+
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        if (event.getClickedInventory() == null) return;
+        if (!event.getClickedInventory().equals(top)) return;
+
+        ((MarketMenu) holder).handleClick(event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onDrag(InventoryDragEvent event) {
+        Inventory top = event.getView().getTopInventory();
+        if (top == null) return;
+        if (top.getHolder() instanceof MarketMenu) {
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/src/main/java/com/nextplugins/nextmarket/inventory/menu/PagedMarketMenu.java
+++ b/src/main/java/com/nextplugins/nextmarket/inventory/menu/PagedMarketMenu.java
@@ -1,0 +1,128 @@
+package com.nextplugins.nextmarket.inventory.menu;
+
+import com.nextplugins.nextmarket.compat.Items;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Paginated menu: content occupies all slots except the last row (controls).
+ * Default control slots (for 6-row / 54-slot inventories): previous=45, back=48, update=49, next=53.
+ */
+public abstract class PagedMarketMenu extends MarketMenu {
+
+    private int page;
+    private final List<PageItem> pageItems = new ArrayList<PageItem>();
+
+    protected PagedMarketMenu(String title, int size) {
+        super(title, size);
+    }
+
+    protected abstract void collectItems(Player player, List<PageItem> items);
+
+    protected void configureControls(Player player) {
+        int lastRowStart = getSize() - 9;
+
+        // Only show navigation arrows when the target page exists.
+        if (page > 0) {
+            setItem(lastRowStart, createPreviousItem(), event -> {
+                page--;
+                refresh();
+            });
+        }
+
+        setItem(lastRowStart + 3, createBackItem(), this::onBack);
+        setItem(lastRowStart + 4, createUpdateItem(player), event -> {
+            page = 0;
+            refresh();
+        });
+
+        if (page < getMaxPage()) {
+            setItem(lastRowStart + 8, createNextItem(), event -> {
+                page++;
+                refresh();
+            });
+        }
+    }
+
+    protected void onBack(InventoryClickEvent event) {
+        event.getWhoClicked().closeInventory();
+    }
+
+    protected ItemStack createPreviousItem() {
+        return Items.named(Items.create("ARROW"), ChatColor.YELLOW + "Página anterior");
+    }
+
+    protected ItemStack createNextItem() {
+        return Items.named(Items.create("ARROW"), ChatColor.YELLOW + "Próxima página");
+    }
+
+    protected ItemStack createBackItem() {
+        return Items.named(Items.create("ARROW"), ChatColor.RED + "Voltar");
+    }
+
+    protected ItemStack createUpdateItem(Player player) {
+        return Items.named(Items.create("EMERALD"), ChatColor.GREEN + "Atualizar");
+    }
+
+    @Override
+    protected final void render(Player player) {
+        pageItems.clear();
+        collectItems(player, pageItems);
+
+        int contentSlots = Math.max(0, getSize() - 9);
+        int from = page * contentSlots;
+        if (from >= pageItems.size() && page > 0) {
+            page = getMaxPage();
+            from = page * contentSlots;
+        }
+
+        int to = Math.min(from + contentSlots, pageItems.size());
+        for (int i = from; i < to; i++) {
+            PageItem pageItem = pageItems.get(i);
+            int slot = i - from;
+            setItem(slot, pageItem.itemStack, pageItem.handler);
+        }
+
+        configureControls(player);
+    }
+
+    protected int getPage() {
+        return page;
+    }
+
+    protected void setPage(int page) {
+        this.page = Math.max(0, page);
+    }
+
+    protected int getMaxPage() {
+        int contentSlots = Math.max(1, getSize() - 9);
+        if (pageItems.isEmpty()) return 0;
+        return (pageItems.size() - 1) / contentSlots;
+    }
+
+    public static final class PageItem {
+        private final ItemStack itemStack;
+        private final Consumer<InventoryClickEvent> handler;
+
+        public PageItem(ItemStack itemStack, Consumer<InventoryClickEvent> handler) {
+            this.itemStack = itemStack;
+            this.handler = handler;
+        }
+
+        public PageItem(ItemStack itemStack) {
+            this(itemStack, null);
+        }
+    }
+
+    protected static List<PageItem> emptyPageItems() {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/com/nextplugins/nextmarket/listener/ProductCreateListener.java
+++ b/src/main/java/com/nextplugins/nextmarket/listener/ProductCreateListener.java
@@ -4,12 +4,14 @@ import com.google.inject.Inject;
 import com.nextplugins.nextmarket.api.event.ProductCreateEvent;
 import com.nextplugins.nextmarket.api.model.product.Product;
 import com.nextplugins.nextmarket.configuration.value.MessageValue;
+import com.nextplugins.nextmarket.compat.PlayerHands;
 import com.nextplugins.nextmarket.manager.AnnouncementManager;
 import com.nextplugins.nextmarket.storage.ProductStorage;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.Objects;
 
@@ -23,13 +25,18 @@ public final class ProductCreateListener implements Listener {
         Player player = event.getPlayer();
         Product product = event.getProduct();
 
-        if (!Objects.equals(player.getItemInHand(), product.getItemStack())) {
+        ItemStack hand = PlayerHands.getMainHand(player);
+        ItemStack expected = product.getItemStack();
+        if (hand == null
+                || hand.getType() != expected.getType()
+                || hand.getAmount() != expected.getAmount()
+                || !hand.isSimilar(expected)) {
             event.setCancelled(true);
             player.sendMessage(MessageValue.get(MessageValue::changedHandItemMessage));
             return;
         }
 
-        player.setItemInHand(null);
+        PlayerHands.clearMainHand(player);
         productStorage.insertOne(product);
 
         if (product.getDestination() == null) {

--- a/src/main/java/com/nextplugins/nextmarket/manager/CategoryManager.java
+++ b/src/main/java/com/nextplugins/nextmarket/manager/CategoryManager.java
@@ -12,7 +12,6 @@ import lombok.val;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -21,7 +20,7 @@ import java.util.Optional;
 @Singleton
 public final class CategoryManager {
 
-    private final Map<String, Category> categoryMap = new LinkedHashMap<>();
+    private final Map<String, Category> categoryMap = new LinkedHashMap<String, Category>();
     private Category trashTableCategory;
 
     @Inject @Named("categories") private Configuration categoriesConfiguration;
@@ -48,29 +47,41 @@ public final class CategoryManager {
         return Optional.ofNullable(this.categoryMap.get(id));
     }
 
-    public Optional<Category> findCategory(@NotNull ItemStack itemStack) {
+    public Optional<Category> findCategory(ItemStack itemStack) {
         val materialData = MaterialData.of(itemStack, false);
         val itemMeta = itemStack.getItemMeta();
-        val nbtItem = new NBTItem(itemStack);
+
+        NBTItem nbtItem = null;
+        try {
+            nbtItem = new NBTItem(itemStack);
+        } catch (Throwable ignored) {
+            // NBT-API may fail on edge cases; continue with material/name matching
+        }
 
         for (Category category : categoryMap.values()) {
             if (category.isTrashTable()) continue;
 
             val configuration = category.getConfiguration();
-            for (String nbt : configuration.getNbts()) {
-                if (nbtItem.hasKey(nbt)) {
-                    return Optional.of(category);
+
+            if (nbtItem != null) {
+                for (String nbt : configuration.getNbts()) {
+                    if (nbt != null && !nbt.isEmpty() && nbtItem.hasKey(nbt)) {
+                        return Optional.of(category);
+                    }
                 }
             }
 
             for (MaterialData material : configuration.getMaterials()) {
-                if (material.equals(materialData)) {
+                if (material.matches(itemStack) || material.equals(materialData)) {
                     return Optional.of(category);
                 }
             }
 
             for (String name : configuration.getNames()) {
-                if (itemMeta != null && itemMeta.getDisplayName() != null && itemMeta.getDisplayName().equalsIgnoreCase(name)) {
+                if (itemMeta != null
+                        && itemMeta.hasDisplayName()
+                        && itemMeta.getDisplayName() != null
+                        && itemMeta.getDisplayName().equalsIgnoreCase(name)) {
                     return Optional.of(category);
                 }
             }

--- a/src/main/java/com/nextplugins/nextmarket/manager/ProductManager.java
+++ b/src/main/java/com/nextplugins/nextmarket/manager/ProductManager.java
@@ -6,6 +6,7 @@ import com.nextplugins.nextmarket.api.model.category.Category;
 import com.nextplugins.nextmarket.api.model.product.Product;
 import com.nextplugins.nextmarket.configuration.value.ConfigValue;
 import com.nextplugins.nextmarket.configuration.value.MessageValue;
+import com.nextplugins.nextmarket.compat.PlayerHands;
 import com.nextplugins.nextmarket.storage.ProductStorage;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -25,8 +26,8 @@ public final class ProductManager {
     }
 
     public Product createProduct(Player player, String destinationName, double price) {
-        final ItemStack itemStack = player.getItemInHand();
-        if (itemStack.getType() == Material.AIR) {
+        final ItemStack itemStack = PlayerHands.getMainHand(player);
+        if (itemStack == null || itemStack.getType() == Material.AIR) {
 
             player.sendMessage(MessageValue.get(MessageValue::invalidItemMessage));
             return null;
@@ -77,7 +78,7 @@ public final class ProductManager {
                 .seller(player)
                 .destination(destination)
                 .price(price)
-                .itemStack(itemStack)
+                .itemStack(itemStack.clone())
                 .category(category)
                 .build();
     }

--- a/src/main/java/com/nextplugins/nextmarket/parser/CategoryParser.java
+++ b/src/main/java/com/nextplugins/nextmarket/parser/CategoryParser.java
@@ -6,13 +6,10 @@ import com.nextplugins.nextmarket.api.model.category.Category;
 import com.nextplugins.nextmarket.api.model.category.CategoryConfiguration;
 import com.nextplugins.nextmarket.api.model.category.CategoryIcon;
 import com.nextplugins.nextmarket.api.model.product.MaterialData;
+import com.nextplugins.nextmarket.compat.Items;
 import com.nextplugins.nextmarket.util.MessageUtils;
-import com.nextplugins.nextmarket.util.TypeUtil;
 import lombok.val;
-import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -22,12 +19,13 @@ import java.util.stream.Collectors;
 @Singleton
 public final class CategoryParser {
 
-    @Nullable
-    public Category parse(@NotNull ConfigurationSection section) {
+    public Category parse(ConfigurationSection section) {
         val iconSection = section.getConfigurationSection("icon");
         val configurationSection = section.getConfigurationSection("configuration");
         if (iconSection == null || configurationSection == null) {
-            NextMarket.getInstance().getLogger().warning("A categoria " + section.getName() + " tem um problema de configuração. (section de ícone ou configuração inválida)");
+            NextMarket.getInstance().getLogger().warning(
+                    "A categoria " + section.getName() + " tem um problema de configuração. (section de ícone ou configuração inválida)"
+            );
             return null;
         }
 
@@ -43,14 +41,22 @@ public final class CategoryParser {
                 .build();
     }
 
-    @NotNull
-    private CategoryIcon parseCategoryIcon(@NotNull ConfigurationSection section) {
-        val itemStack = TypeUtil.convertFromLegacy(
-                section.getString("material"),
-                (byte) section.getInt("data"));
+    private CategoryIcon parseCategoryIcon(ConfigurationSection section) {
+        String materialName = section.getString("material", "BARRIER");
+        int data = section.getInt("data", 0);
+
+        MaterialData materialData = Items.parseMaterialData(
+                data > 0 ? materialName + ":" + data : materialName
+        );
+        if (materialData == null) {
+            materialData = Items.parseMaterialData(materialName);
+        }
+        if (materialData == null) {
+            materialData = new MaterialData(com.cryptomorin.xseries.XMaterial.BARRIER, null, true);
+        }
 
         return CategoryIcon.builder()
-                .materialData(itemStack == null ? new MaterialData(Material.BARRIER, 0, false) : MaterialData.of(itemStack, false))
+                .materialData(materialData)
                 .enchant(section.getBoolean("enchant"))
                 .inventorySlot(section.getInt("inventorySlot"))
                 .build();
@@ -66,7 +72,7 @@ public final class CategoryParser {
                         .collect(Collectors.toList())
                         : Collections.emptyList())
                 .materials(section.getStringList("materials").stream()
-                        .map(TypeUtil::convertFromLegacy)
+                        .map(Items::parseMaterialData)
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList()))
                 .nbts(section.contains("nbts") ? section.getStringList("nbts")
@@ -77,7 +83,6 @@ public final class CategoryParser {
                 .build();
     }
 
-    // Apache method
     public static boolean isBlank(CharSequence sequence) {
         val strLen = sequence.length();
         if (strLen == 0) return true;

--- a/src/main/java/com/nextplugins/nextmarket/parser/InventoryButtonParser.java
+++ b/src/main/java/com/nextplugins/nextmarket/parser/InventoryButtonParser.java
@@ -1,12 +1,12 @@
 package com.nextplugins.nextmarket.parser;
 
+import com.cryptomorin.xseries.XMaterial;
 import com.google.inject.Singleton;
 import com.nextplugins.nextmarket.api.model.product.MaterialData;
+import com.nextplugins.nextmarket.compat.Items;
 import com.nextplugins.nextmarket.inventory.button.InventoryButton;
 import com.nextplugins.nextmarket.util.MessageUtils;
-import com.nextplugins.nextmarket.util.TypeUtil;
 import lombok.val;
-import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.stream.Collectors;
@@ -15,17 +15,25 @@ import java.util.stream.Collectors;
 public final class InventoryButtonParser {
 
     public InventoryButton parse(ConfigurationSection section) {
+        String materialName = section.getString("material", "BARRIER");
+        int data = section.getInt("data", 0);
 
-        val itemStack = TypeUtil.convertFromLegacy(
-                section.getString("material"),
-                (byte) section.getInt("data"));
+        MaterialData materialData = Items.parseMaterialData(
+                data > 0 ? materialName + ":" + data : materialName
+        );
+        if (materialData == null) {
+            materialData = Items.parseMaterialData(materialName);
+        }
+        if (materialData == null) {
+            materialData = new MaterialData(XMaterial.BARRIER, null, true);
+        }
 
         return InventoryButton.builder()
                 .displayName(MessageUtils.colored(section.getString("displayName")))
                 .lore(section.getStringList("lore").stream()
                         .map(MessageUtils::colored)
                         .collect(Collectors.toList()))
-                .materialData(itemStack == null ? new MaterialData(Material.BARRIER, 0, false) : MaterialData.of(itemStack, false))
+                .materialData(materialData)
                 .inventorySlot(section.getInt("inventorySlot"))
                 .build();
     }

--- a/src/main/java/com/nextplugins/nextmarket/registry/InventoryRegistry.java
+++ b/src/main/java/com/nextplugins/nextmarket/registry/InventoryRegistry.java
@@ -1,7 +1,11 @@
 package com.nextplugins.nextmarket.registry;
 
 import com.google.inject.Singleton;
-import com.nextplugins.nextmarket.inventory.*;
+import com.nextplugins.nextmarket.inventory.CategoryInventory;
+import com.nextplugins.nextmarket.inventory.ConfirmationInventory;
+import com.nextplugins.nextmarket.inventory.MarketInventory;
+import com.nextplugins.nextmarket.inventory.PersonalMarketInventory;
+import com.nextplugins.nextmarket.inventory.SellingMarketInventory;
 import lombok.Getter;
 
 @Getter
@@ -15,11 +19,11 @@ public final class InventoryRegistry {
     private SellingMarketInventory sellingMarketInventory;
 
     public void init() {
-        this.marketInventory = new MarketInventory().init();
-        this.categoryInventory = new CategoryInventory().init();
-        this.confirmationInventory = new ConfirmationInventory().init();
-        this.personalMarketInventory = new PersonalMarketInventory().init();
-        this.sellingMarketInventory = new SellingMarketInventory().init();
+        this.marketInventory = new MarketInventory();
+        this.categoryInventory = new CategoryInventory();
+        this.confirmationInventory = new ConfirmationInventory();
+        this.personalMarketInventory = new PersonalMarketInventory();
+        this.sellingMarketInventory = new SellingMarketInventory();
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/util/MaterialUtils.java
+++ b/src/main/java/com/nextplugins/nextmarket/util/MaterialUtils.java
@@ -1,26 +1,16 @@
 package com.nextplugins.nextmarket.util;
 
-import lombok.val;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
+import com.nextplugins.nextmarket.compat.Items;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.MaterialData;
 
 /**
- * @author Yuhtin
- * Github: https://github.com/Yuhtin
+ * @deprecated Use {@link Items} instead.
  */
+@Deprecated
 public class MaterialUtils {
 
     public static ItemStack convertFromLegacy(String materialName, int damage) {
-
-        try {
-            val material = Material.valueOf("LEGACY_" + materialName);
-            return new ItemStack(Bukkit.getUnsafe().fromLegacy(new MaterialData(material, (byte) damage)));
-        } catch (Exception error) {
-            return new ItemStack(Material.getMaterial(materialName), 1, (short) damage);
-        }
-
+        return Items.create(materialName, damage);
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/util/TextUtils.java
+++ b/src/main/java/com/nextplugins/nextmarket/util/TextUtils.java
@@ -5,51 +5,56 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.Method;
-import java.util.logging.Level;
 
+/**
+ * Chat helpers. Item-hover uses a best-effort path and falls back to plain text
+ * when the server cannot serialize the item (common on remapped Paper builds).
+ */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TextUtils {
 
     @Nullable
     public static TextComponent sendItemTooltipMessage(String message, ItemStack item) {
-        String itemJson = convertItemStackToJson(item);
-        if (itemJson == null) return null;
-
-        BaseComponent[] hoverEventComponents = {new TextComponent(itemJson)};
-        HoverEvent event = new HoverEvent(HoverEvent.Action.SHOW_ITEM, hoverEventComponents);
+        if (message == null) return null;
 
         TextComponent component = new TextComponent(message);
-        component.setHoverEvent(event);
+        String itemJson = convertItemStackToJson(item);
+        if (itemJson == null) {
+            return component;
+        }
+
+        try {
+            BaseComponent[] hoverEventComponents = {new TextComponent(itemJson)};
+            HoverEvent event = new HoverEvent(HoverEvent.Action.SHOW_ITEM, hoverEventComponents);
+            component.setHoverEvent(event);
+        } catch (Throwable ignored) {
+            // SHOW_ITEM payload formats differ across versions — plain text is fine.
+        }
 
         return component;
     }
 
     @Nullable
     private static String convertItemStackToJson(ItemStack itemStack) {
-        Class<?> craftItemStackClazz = ReflectionUtils.getOBCClass("inventory.CraftItemStack");
-        Method asNMSCopyMethod = ReflectionUtils.getMethod(craftItemStackClazz, "asNMSCopy", ItemStack.class);
-        Class<?> nmsItemStackClazz = ReflectionUtils.getNMSClass("ItemStack");
+        if (itemStack == null) return null;
 
-        Class<?> nbtTagCompoundClazz = ReflectionUtils.getNMSClass("NBTTagCompound");
-        if (nbtTagCompoundClazz == null) return null;
-
-        Method saveNmsItemStackMethod = ReflectionUtils.getMethod(nmsItemStackClazz, "save", nbtTagCompoundClazz);
-        Object itemAsJsonObject;
-
+        // Prefer NBT-API when available (shaded, multi-version).
         try {
-            Object nmsNbtTagCompoundObj = nbtTagCompoundClazz.newInstance();
-            Object nmsItemStackObj = asNMSCopyMethod.invoke(null, itemStack);
-            itemAsJsonObject = saveNmsItemStackMethod.invoke(nmsItemStackObj, nmsNbtTagCompoundObj);
-        } catch (Throwable t) {
-            Bukkit.getLogger().log(Level.SEVERE, "failed to serialize itemstack to nms item", t);
-            return null;
+            de.tr7zw.changeme.nbtapi.NBTItem nbtItem = new de.tr7zw.changeme.nbtapi.NBTItem(itemStack);
+            String nbt = nbtItem.toString();
+            if (nbt != null && !nbt.isEmpty()) {
+                String type = itemStack.getType().name().toLowerCase();
+                int count = itemStack.getAmount();
+                // Legacy hover format used by many 1.8–1.12 clients
+                return "{id:\"" + type + "\",Count:" + count + "b,tag:" + nbt + "}";
+            }
+        } catch (Throwable ignored) {
         }
-        return itemAsJsonObject.toString();
+
+        return null;
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/util/TypeUtil.java
+++ b/src/main/java/com/nextplugins/nextmarket/util/TypeUtil.java
@@ -1,51 +1,21 @@
 package com.nextplugins.nextmarket.util;
 
-import com.nextplugins.nextmarket.NextMarket;
 import com.nextplugins.nextmarket.api.model.product.MaterialData;
-import lombok.val;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
+import com.nextplugins.nextmarket.compat.Items;
 import org.bukkit.inventory.ItemStack;
 
+/**
+ * @deprecated Use {@link Items} instead. Kept for binary compatibility of any external callers.
+ */
+@Deprecated
 public final class TypeUtil {
 
     public static ItemStack convertFromLegacy(String materialName, int damage) {
-        try {
-            return new ItemStack(Material.valueOf(materialName), 1, (short) damage);
-        } catch (Exception exception) {
-            try {
-                val material = Material.valueOf("LEGACY_" + materialName);
-                return new ItemStack(Bukkit.getUnsafe().fromLegacy(new org.bukkit.material.MaterialData(material, (byte) damage)));
-            } catch (Exception error) {
-                NextMarket.getInstance().getLogger().warning("O material " + materialName + " é nulo, verifique a categories.yml");
-                return null;
-            }
-        }
+        return Items.create(materialName, damage);
     }
 
     public static MaterialData convertFromLegacy(String materialData) {
-        String materialName = materialData;
-        int data = 0;
-        boolean ignoreData = true;
-
-        if (materialData.contains(":")) {
-            val args = materialData.split(":");
-
-            val type = args[1];
-            if (!type.equalsIgnoreCase("all")) {
-            	data = Integer.parseInt(type);
-            	ignoreData = false;
-            }
-
-            materialName = args[0];
-        }
-
-        val itemStack = convertFromLegacy(materialName, data);
-        if (itemStack != null && itemStack.getType() != Material.AIR) {
-            return MaterialData.of(itemStack, ignoreData);
-        }
-
-        return null;
+        return Items.parseMaterialData(materialData);
     }
 
 }

--- a/src/main/java/com/nextplugins/nextmarket/util/VersionUtils.java
+++ b/src/main/java/com/nextplugins/nextmarket/util/VersionUtils.java
@@ -1,11 +1,15 @@
 package com.nextplugins.nextmarket.util;
 
+import com.nextplugins.nextmarket.compat.ServerVersion;
+
+/**
+ * @deprecated Use {@link ServerVersion} instead.
+ */
+@Deprecated
 public final class VersionUtils {
 
     public static boolean isLegacy() {
-        int version = ReflectionUtils.getVersionNumber();
-
-        return version < 111;
+        return ServerVersion.isLegacy();
     }
 
 }

--- a/src/main/resources/categories.yml
+++ b/src/main/resources/categories.yml
@@ -1,20 +1,16 @@
 # Categorias do /mercado ver
-
-# Para que serve?
-# Ao anunciar, o item irá diretamente para categoria qual corresponde,
-# além de também, servir para melhor organização do mercado.
-
-# NOVIDADE v1.2.0 (apenas 1.12 1.11 1.10 1.9 e 1.8)
-# Você pode definir a 'data' que o item precisa ter para ser de tal categoria
-# Por exemplo, você pode definir um tipo específico de cor de corante para uma categoria
-# apenas use este formato:
-# MATERIAL:DATA -> Exemplo abaixo
-# WOOL:14 -> Apenas a lã vermelha poderá ser vendida na categoria
 #
-# ATENÇÃO
-# Caso você queira que TODAS as cores de lã funcione na categoria, siga o formato abaixo:
-# MATERIAL:all -> Exemplo abaixo:
-# - "WOOL:all"
+# Compatível com Minecraft 1.8 até 26.2 (nomes modernos e legacy).
+# Materiais inexistentes na versão do servidor são ignorados com warning no console.
+#
+# Formatos de material aceitos:
+#   DIAMOND_SWORD          -> nome moderno ou legacy
+#   WOOL:14                -> material + data (só relevante em 1.8–1.12)
+#   WOOL:all               -> ignora data (todas as variantes)
+#   PLAYER_HEAD / SKULL_ITEM:3  -> cabeças (ambos aceitos)
+#
+# Liste quantos sinônimos quiser (ex.: REDSTONE_TORCH e REDSTONE_TORCH_ON);
+# o plugin usa o que existir na versão atual.
 
 
 inventory:
@@ -30,7 +26,7 @@ inventory:
           - '&7Clique para ver os itens que estão vendendo para você'
         inventorySlot: 39
       sellingMarket:
-        material: EYE_OF_ENDER
+        material: ENDER_EYE
         data: 0
         displayName: "&aItens Anunciados"
         lore:
@@ -66,8 +62,8 @@ inventory:
       - '&aClique para coletar seu item.'
     buttons:
       update:
-        material: SKULL_ITEM # LEGACY_SKULL_ITEM para versões iguais ou superiores à 1.12
-        data: 3
+        material: PLAYER_HEAD
+        data: 0
         displayName: "&6Atualizar"
         lore:
           - '&7Clique para atualizar os seus itens anunciados!'
@@ -82,8 +78,8 @@ inventory:
       - ''
     buttons:
       update:
-        material: SKULL_ITEM # LEGACY_SKULL_ITEM para versões iguais ou superiores à 1.12
-        data: 3
+        material: PLAYER_HEAD
+        data: 0
         displayName: "&6Atualizar"
         lore:
           - '&7Clique para atualizar os itens do mercado pessoal!'
@@ -252,13 +248,13 @@ categories:
         - "TNT"
         - "REDSTONE"
         - "REDSTONE_BLOCK"
-        - "REDSTONE_TORCH" # 1.13 ou superior ( retire caso não precise )
-        - "REDSTONE_TORCH_ON" # 1.8 ( retire caso não precise )
-        - "REDSTONE_TORCH_OFF" # 1.8 ( retire caso não precise )
-        - "REPEATER" # 1.13 ou superior ( retire caso não precise )
-        - "DIODE" # 1.12 ou inferior ( retire caso não precise )
-        - "COMPARATOR" # 1.13 ou superior ( retire caso não precise )
-        - "REDSTONE_COMPARATOR" # 1.12 ou inferior ( retire caso não precise )
+        - "REDSTONE_TORCH"
+        - "REDSTONE_TORCH_ON"
+        - "REDSTONE_TORCH_OFF"
+        - "REPEATER"
+        - "DIODE"
+        - "COMPARATOR"
+        - "REDSTONE_COMPARATOR"
         - "DROPPER"
         - "DISPENSER"
       nbts: # Caso o item tenha esta tag nbt, ele virá para esta categoria
@@ -300,7 +296,7 @@ categories:
       - ''
       - '&aClique para abrir.'
     icon:
-      material: MOB_SPAWNER
+      material: SPAWNER
       data: 0
       enchant: false
       inventorySlot: 20
@@ -309,6 +305,7 @@ categories:
       names:
         - "&eGerador de Monstros"
       materials:
+        - "SPAWNER"
         - "MOB_SPAWNER"
       nbts: # Caso o item tenha esta tag nbt, ele virá para esta categoria
         - 'CustomSpawnerType'
@@ -323,8 +320,8 @@ categories:
       - ''
       - '&aClique para abrir.'
     icon:
-      material: SKULL_ITEM
-      data: 3
+      material: PLAYER_HEAD
+      data: 0
       enchant: false
       inventorySlot: 21
     configuration:
@@ -332,6 +329,7 @@ categories:
       names:
         - ""
       materials:
+        - "PLAYER_HEAD"
         - "SKULL_ITEM"
       nbts: # Caso o item tenha esta tag nbt, ele virá para esta categoria
         - 'RankupHead'


### PR DESCRIPTION
## Summary
- Add full multi-version support (Minecraft **1.8.8 → 26.2**) via XSeries, NBT-API 2.15.x, and a new `compat` layer (server version, main hand, materials, skulls).
- Replace abandoned HenryFabio inventory-api with a Bukkit-native GUI (`MarketMenu` / `PagedMarketMenu`); pagination arrows only appear when the previous/next page exists.
- Bump plugin to **2.0.0**, Gradle 7.6.4, Java 8 bytecode; modern + legacy material names accepted in `categories.yml`.

## Test plan
- [x] Build `shadowJar` successfully
- [x] Smoke-tested in-game (menus, sell/buy, pagination arrows)
- [x] Optional: verify on 1.8.8, 1.12.2, 1.16/1.20, and 1.21/26.2 with Vault + economy